### PR TITLE
feat(hooks): add Git hooks with Lefthook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ roxabi_boilerplate/
 └── docs/             # Documentation
 ```
 
+## Git Hooks
+
+Git hooks are configured using [Lefthook](https://github.com/evilmartians/lefthook) and are installed automatically on `bun install`.
+
+| Hook | Purpose | Speed |
+|------|---------|-------|
+| **Pre-commit** | Auto-format staged files with Biome | &lt;1s |
+| **Pre-push** | Full validation (lint, typecheck, tests) | &lt;30s (cached) |
+
+**Bypass for emergencies:** Use `--no-verify` flag (CI is the ultimate enforcement).
+
 ## Development Process
 
 ```

--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,6 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", "build", ".next", ".turbo", "*.min.js"]
+    "ignore": ["node_modules", "dist", "build", ".next", ".turbo", "*.min.js", "coverage"]
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@vitejs/plugin-react": "^5.1.3",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^28.0.0",
+        "lefthook": "^2.0.16",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "turbo": "^2.3.0",
@@ -740,6 +741,28 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lefthook": ["lefthook@2.0.16", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.0.16", "lefthook-darwin-x64": "2.0.16", "lefthook-freebsd-arm64": "2.0.16", "lefthook-freebsd-x64": "2.0.16", "lefthook-linux-arm64": "2.0.16", "lefthook-linux-x64": "2.0.16", "lefthook-openbsd-arm64": "2.0.16", "lefthook-openbsd-x64": "2.0.16", "lefthook-windows-arm64": "2.0.16", "lefthook-windows-x64": "2.0.16" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ABs3M5V9c4nqxFnZO509HXuQTu8GM8hmqc9ruV0acQ81yKlxEq70MRoYP5Z1dr5le326X8vA5qj3arJA36yE3A=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.0.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kjVHkD7rfPa7M0aKJSx/yatdV9uC6o3cJyzM9zk7cg5HD7alSwchFalgF/P0w6nt7C02rAUx8C05qiWCDWaKeA=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.0.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-tbJ0mdT49DNRLqknro0BvWrYNC23TTcqBJFQnQ32pq1/H9B87bTNKvKKAtogp/saxfHUzkIq1i3twZlBZ3G3Xw=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.0.16", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wa1KFD5tSUhw3tuetVef/BCSxbbmS7auTDNdoLx3WFeuN5RS15woSN9+E8GPGOOY1g2HCsgdLrhrexEomulfjQ=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.0.16", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UXowfn2e94AwNk9UuoePRK+qiF15jZsssiyA15VK5GTtxpn6Sn+Z2QFciofxJczXXxM4abaf7qgx2OoJBt32VA=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.0.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-U355elz4Z0AHSVqxfcglN09TGR86ov/GtYlliDknci2mmz6EWLiD3dTYnqJiwa4dYxqmuCDc/DvAL9rgb3YJiQ=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.0.16", "", { "os": "linux", "cpu": "x64" }, "sha512-7eAvBeWGAgjOKZ23OQbjJINLPImDIuDeX8dXOfk+aI6IFt2X6KCzRkp+ASUvGQtrPuNZQZT43EhW0/1jZU14ZQ=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.0.16", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-Fcd+E17ZkWGnRSQINb5gf+rNy2So5PYn5mBljiC31dl+TgWM8Wy46mSEGveHo7lKCO3q+DkmHIa50Qm58G03AQ=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.0.16", "", { "os": "openbsd", "cpu": "x64" }, "sha512-uL5nOkz8eBtQHped0/tB5X8clZ5kfnyjQrv1fpKbGAjeFHI2J+GmRqcn6Awq2IeuBbQvkyV6jDjpATyHBp5mCA=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.0.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-U61bNWzD6Vd2kjuJ7b4voPfTQ4mlBFOyTpCU3k/h0YjpKDQEFT1T5fDKkDothdnw/JVDSgrclIcfAY7Jyr/UIg=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.0.16", "", { "os": "win32", "cpu": "x64" }, "sha512-dCHi2+hebhPI0LQUGRNjPMsGRyXhrTN3Y/b8M4HO8KVyGamKB3Yemf67ya81tZopDkxNVy5XUBXLYWKGhnAfLQ=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+  parallel: true
+  commands:
+    biome:
+      glob: "*.{js,ts,jsx,tsx,json,jsonc}"
+      run: bunx biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: true
+  commands:
+    lint:
+      run: bun run lint
+    typecheck:
+      run: bun run typecheck
+    test:
+      run: bun run test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
+    "prepare": "lefthook install",
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "biome check .",
@@ -19,7 +20,9 @@
     "docs": "docker compose -f apps/docs/docker-compose.yml up docs",
     "docs:prod": "docker compose -f apps/docs/docker-compose.yml up docs-prod",
     "docs:build": "docker compose -f apps/docs/docker-compose.yml build docs-prod",
-    "i18n:validate": "bun run scripts/validate-translations.ts"
+    "i18n:validate": "bun run scripts/validate-translations.ts",
+    "typecheck:affected": "turbo run typecheck --filter=...[origin/main]",
+    "test:affected": "turbo run test --filter=...[origin/main]"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
@@ -32,6 +35,7 @@
     "@vitejs/plugin-react": "^5.1.3",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.0.0",
+    "lefthook": "^2.0.16",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "turbo": "^2.3.0",


### PR DESCRIPTION
## Summary

- Add Lefthook configuration for pre-commit (Biome auto-format) and pre-push (lint, typecheck, tests) hooks
- Hooks install automatically on `bun install` via prepare script
- Add `*:affected` scripts for CI alignment
- Update README with Git Hooks documentation

## Implementation

| Hook | Purpose | Speed |
|------|---------|-------|
| **Pre-commit** | Auto-format staged files with Biome | <1s |
| **Pre-push** | Full validation (lint, typecheck, tests) | <30s (cached) |

## Test plan

- [x] `bun install` triggers `lefthook install` automatically
- [x] Pre-commit formats staged files with Biome
- [x] Pre-push runs lint, typecheck, test in parallel
- [x] All validations pass (38 tests)
- [x] `--no-verify` bypass available for emergencies

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)