### PR TITLE
chore(deps): upgrade lefthook, i18next, and biome to latest versions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,11 +21,11 @@
     "fumadocs-core": "^16.5.0",
     "fumadocs-mdx": "^14.2.5",
     "fumadocs-ui": "^16.5.0",
-    "i18next": "^24.2.2",
+    "i18next": "^25.8.1",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-i18next": "^15.4.1",
+    "react-i18next": "^16.5.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,5 @@
-import { changeLanguage, useAvailableLocales, useTranslation } from '@/lib/i18n'
 import type { Locale } from '@/lib/i18n'
+import { changeLanguage, useAvailableLocales, useTranslation } from '@/lib/i18n'
 
 type LanguageSwitcherProps = {
   /**

--- a/apps/web/src/components/docs-error-boundary.tsx
+++ b/apps/web/src/components/docs-error-boundary.tsx
@@ -1,7 +1,7 @@
-import { baseOptions } from '@/lib/layout.shared'
 import { Link } from '@tanstack/react-router'
 import { HomeLayout } from 'fumadocs-ui/layouts/home'
 import { Component, type ReactNode } from 'react'
+import { baseOptions } from '@/lib/layout.shared'
 
 interface Props {
   children: ReactNode

--- a/apps/web/src/components/not-found.tsx
+++ b/apps/web/src/components/not-found.tsx
@@ -1,6 +1,6 @@
-import { baseOptions } from '@/lib/layout.shared'
 import { Link } from '@tanstack/react-router'
 import { HomeLayout } from 'fumadocs-ui/layouts/home'
+import { baseOptions } from '@/lib/layout.shared'
 
 export function NotFound() {
   return (

--- a/apps/web/src/lib/i18n/hooks.ts
+++ b/apps/web/src/lib/i18n/hooks.ts
@@ -28,6 +28,7 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
  */
 export function useI18nContext(): I18nRouterContext | undefined {
   try {
+    // biome-ignore lint/correctness/useHookAtTopLevel: intentional try/catch for graceful fallback outside router
     const context = useRouteContext({ strict: false }) as { i18n?: I18nRouterContext } | undefined
     return context?.i18n
   } catch {
@@ -64,7 +65,7 @@ export function useTranslation(ns?: Namespace | Namespace[]) {
       const result = defaultValue ? i18nextResult.t(key, defaultValue) : i18nextResult.t(key)
       return typeof result === 'string' ? result : (defaultValue ?? key)
     },
-    [i18nContext?.resources, namespace, i18nextResult.t]
+    [i18nContext?.resources, namespace, i18nextResult]
   )
 
   return {

--- a/apps/web/src/lib/i18n/index.ts
+++ b/apps/web/src/lib/i18n/index.ts
@@ -1,34 +1,4 @@
 // Types
-export {
-  DEFAULT_LOCALE,
-  DEFAULT_NAMESPACE,
-  LOCALE_COOKIE_MAX_AGE,
-  LOCALE_COOKIE_NAME,
-  LOCALES,
-  NAMESPACES,
-  type DetectedLanguage,
-  type FormatOptions,
-  type LanguageDetectionSource,
-  type Locale,
-  type LocaleContext,
-  type Namespace,
-  type TranslationResources,
-} from './types'
-
-// Configuration
-export { getClientConfig, getServerConfig, i18nConfig } from './config'
-
-// Server utilities
-export {
-  createServerI18n,
-  detectLanguage,
-  getLocaleFromCookie,
-  getLocaleFromHeader,
-  getLocaleFromPath,
-  getLocaleCookieHeader,
-  isValidLocale,
-  loadTranslations,
-} from './server'
 
 // Client utilities
 export {
@@ -39,11 +9,37 @@ export {
   initClientI18n,
 } from './client'
 
+// Configuration
+export { getClientConfig, getServerConfig, i18nConfig } from './config'
+// Router context
+export { createI18nContext, type I18nRouterContext, loadI18nNamespaces } from './context'
 // React hooks
 export { useAvailableLocales, useI18nContext, useLocale, useTranslation } from './hooks'
-
-// Router context
-export { createI18nContext, loadI18nNamespaces, type I18nRouterContext } from './context'
-
 // SEO utilities
 export { getCanonicalUrl, HreflangTags } from './seo'
+// Server utilities
+export {
+  createServerI18n,
+  detectLanguage,
+  getLocaleCookieHeader,
+  getLocaleFromCookie,
+  getLocaleFromHeader,
+  getLocaleFromPath,
+  isValidLocale,
+  loadTranslations,
+} from './server'
+export {
+  DEFAULT_LOCALE,
+  DEFAULT_NAMESPACE,
+  type DetectedLanguage,
+  type FormatOptions,
+  type LanguageDetectionSource,
+  LOCALE_COOKIE_MAX_AGE,
+  LOCALE_COOKIE_NAME,
+  LOCALES,
+  type Locale,
+  type LocaleContext,
+  NAMESPACES,
+  type Namespace,
+  type TranslationResources,
+} from './types'

--- a/apps/web/src/lib/i18n/server.ts
+++ b/apps/web/src/lib/i18n/server.ts
@@ -3,9 +3,9 @@ import { getServerConfig } from './config'
 import {
   DEFAULT_LOCALE,
   type DetectedLanguage,
-  LOCALES,
   LOCALE_COOKIE_MAX_AGE,
   LOCALE_COOKIE_NAME,
+  LOCALES,
   type Locale,
   type Namespace,
 } from './types'

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,6 +1,6 @@
+import { type AnyRouter, createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { NotFound } from '@/components/not-found'
 import { type I18nRouterContext, initClientI18n } from '@/lib/i18n'
-import { type AnyRouter, createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 
 export type RouterContext = {

--- a/apps/web/src/routes/$locale/_layout.tsx
+++ b/apps/web/src/routes/$locale/_layout.tsx
@@ -1,15 +1,15 @@
-import {
-  DEFAULT_LOCALE,
-  type Locale,
-  type Namespace,
-  createServerI18n,
-  isValidLocale,
-  loadI18nNamespaces,
-} from '@/lib/i18n'
-import type { RouterContext } from '@/router'
-import { Outlet, createFileRoute, redirect, useRouteContext } from '@tanstack/react-router'
+import { createFileRoute, Outlet, redirect, useRouteContext } from '@tanstack/react-router'
 import { use, useMemo } from 'react'
 import { I18nextProvider } from 'react-i18next'
+import {
+  createServerI18n,
+  DEFAULT_LOCALE,
+  isValidLocale,
+  type Locale,
+  loadI18nNamespaces,
+  type Namespace,
+} from '@/lib/i18n'
+import type { RouterContext } from '@/router'
 
 export const Route = createFileRoute('/$locale/_layout')({
   beforeLoad: async ({ params, context }) => {

--- a/apps/web/src/routes/$locale/dashboard.tsx
+++ b/apps/web/src/routes/$locale/dashboard.tsx
@@ -1,7 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
 import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { HreflangTags, loadI18nNamespaces, useLocale, useTranslation } from '@/lib/i18n'
 import type { RouterContext } from '@/router'
-import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/$locale/dashboard')({
   loader: async ({ context }) => {

--- a/apps/web/src/routes/$locale/index.tsx
+++ b/apps/web/src/routes/$locale/index.tsx
@@ -1,7 +1,7 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { HomeLayout } from 'fumadocs-ui/layouts/home'
 import { useTranslation } from '@/lib/i18n'
 import { baseOptions } from '@/lib/layout.shared'
-import { Link, createFileRoute } from '@tanstack/react-router'
-import { HomeLayout } from 'fumadocs-ui/layouts/home'
 
 export const Route = createFileRoute('/$locale/')({
   component: LocalizedHome,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,16 +1,16 @@
+import {
+  createRootRouteWithContext,
+  HeadContent,
+  Outlet,
+  redirect,
+  Scripts,
+} from '@tanstack/react-router'
+import { RootProvider } from 'fumadocs-ui/provider/tanstack'
+import type * as React from 'react'
 import { createI18nContext, detectLanguage } from '@/lib/i18n'
 import { getInvalidLocaleRedirect } from '@/lib/i18n/server'
 import type { RouterContext } from '@/router'
 import appCss from '@/styles/app.css?url'
-import {
-  HeadContent,
-  Outlet,
-  Scripts,
-  createRootRouteWithContext,
-  redirect,
-} from '@tanstack/react-router'
-import { RootProvider } from 'fumadocs-ui/provider/tanstack'
-import type * as React from 'react'
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: ({ context, location }) => {

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -1,7 +1,4 @@
 import browserCollections from 'fumadocs-mdx:collections/browser'
-import { DocsErrorBoundary } from '@/components/docs-error-boundary'
-import { baseOptions } from '@/lib/layout.shared'
-import { source } from '@/lib/source'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { useFumadocsLoader } from 'fumadocs-core/source/client'
@@ -9,6 +6,9 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs'
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import { Suspense } from 'react'
+import { DocsErrorBoundary } from '@/components/docs-error-boundary'
+import { baseOptions } from '@/lib/layout.shared'
+import { source } from '@/lib/source'
 
 export const Route = createFileRoute('/docs/$')({
   component: Page,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,5 +1,5 @@
-import { DEFAULT_LOCALE, detectLanguage } from '@/lib/i18n'
 import { createFileRoute, redirect } from '@tanstack/react-router'
+import { DEFAULT_LOCALE, detectLanguage } from '@/lib/i18n'
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -20,7 +18,8 @@
         "useImportType": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn"
+        "noExplicitAny": "warn",
+        "noDocumentCookie": "warn"
       }
     }
   },
@@ -38,17 +37,18 @@
     }
   },
   "files": {
-    "ignore": [
-      "node_modules",
-      "dist",
-      "build",
-      ".next",
-      ".turbo",
-      "*.min.js",
-      "coverage",
-      ".source",
-      ".output",
-      "routeTree.gen.ts"
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/build",
+      "!**/.next",
+      "!**/.turbo",
+      "!**/*.min.js",
+      "!**/coverage",
+      "!**/.source",
+      "!**/.output",
+      "!**/routeTree.gen.ts"
     ]
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "roxabi-boilerplate",
       "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
+        "@biomejs/biome": "^2.3.14",
         "@commitlint/cli": "^20.4.1",
         "@commitlint/config-conventional": "^20.4.1",
         "@playwright/test": "^1.58.1",
@@ -17,7 +17,7 @@
         "@vitejs/plugin-react": "^5.1.3",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^28.0.0",
-        "lefthook": "^2.0.16",
+        "lefthook": "^2.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "turbo": "^2.8.2",
@@ -47,11 +47,11 @@
         "fumadocs-core": "^16.5.0",
         "fumadocs-mdx": "^14.2.5",
         "fumadocs-ui": "^16.5.0",
-        "i18next": "^24.2.2",
+        "i18next": "^25.8.1",
         "lucide-react": "^0.563.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-i18next": "^15.4.1",
+        "react-i18next": "^16.5.4",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -151,23 +151,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
     "@commitlint/cli": ["@commitlint/cli@20.4.1", "", { "dependencies": { "@commitlint/format": "^20.4.0", "@commitlint/lint": "^20.4.1", "@commitlint/load": "^20.4.0", "@commitlint/read": "^20.4.0", "@commitlint/types": "^20.4.0", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-uuFKKpc7OtQM+6SRqT+a4kV818o1pS+uvv/gsRhyX7g4x495jg+Q7P0+O9VNGyLXBYP0syksS7gMRDJKcekr6A=="],
 
@@ -855,7 +855,7 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "i18next": ["i18next@24.2.3", "", { "dependencies": { "@babel/runtime": "^7.26.10" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A=="],
+    "i18next": ["i18next@25.8.1", "", { "dependencies": { "@babel/runtime": "^7.28.4" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-nFFxhwcRNggIrkv2hx/xMYVMG7Z8iMUA4ZuH4tgcbZiI0bK1jn3kSDIXNWuQDt1xVAu7mb7Qn82TpH7ZAk/okA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -921,27 +921,27 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "lefthook": ["lefthook@2.0.16", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.0.16", "lefthook-darwin-x64": "2.0.16", "lefthook-freebsd-arm64": "2.0.16", "lefthook-freebsd-x64": "2.0.16", "lefthook-linux-arm64": "2.0.16", "lefthook-linux-x64": "2.0.16", "lefthook-openbsd-arm64": "2.0.16", "lefthook-openbsd-x64": "2.0.16", "lefthook-windows-arm64": "2.0.16", "lefthook-windows-x64": "2.0.16" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ABs3M5V9c4nqxFnZO509HXuQTu8GM8hmqc9ruV0acQ81yKlxEq70MRoYP5Z1dr5le326X8vA5qj3arJA36yE3A=="],
+    "lefthook": ["lefthook@2.1.0", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.0", "lefthook-darwin-x64": "2.1.0", "lefthook-freebsd-arm64": "2.1.0", "lefthook-freebsd-x64": "2.1.0", "lefthook-linux-arm64": "2.1.0", "lefthook-linux-x64": "2.1.0", "lefthook-openbsd-arm64": "2.1.0", "lefthook-openbsd-x64": "2.1.0", "lefthook-windows-arm64": "2.1.0", "lefthook-windows-x64": "2.1.0" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-+vS+yywGQW6CN1J1hbGkez//6ixGHIQqfxDN/d3JDm531w9GfGt2lAWTDfZTw/CEl80XsN0raFcnEraR3ldw9g=="],
 
-    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.0.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kjVHkD7rfPa7M0aKJSx/yatdV9uC6o3cJyzM9zk7cg5HD7alSwchFalgF/P0w6nt7C02rAUx8C05qiWCDWaKeA=="],
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u2hjHLQXWSFfzO7ln2n/uEydSzfC9sc5cDC7tvKSuOdhvBwaJ0AQ7ZeuqqCQ4YfVIJfYOom1SVE9CBd10FVyig=="],
 
-    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.0.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-tbJ0mdT49DNRLqknro0BvWrYNC23TTcqBJFQnQ32pq1/H9B87bTNKvKKAtogp/saxfHUzkIq1i3twZlBZ3G3Xw=="],
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-zz5rcyrtOZpxon7uE+c0KC/o2ypJeLZql5CL0Y9oaTuECbmhfokm8glsGnyWstW/++PuMpZYYr/qsCJA5elxkQ=="],
 
-    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.0.16", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wa1KFD5tSUhw3tuetVef/BCSxbbmS7auTDNdoLx3WFeuN5RS15woSN9+E8GPGOOY1g2HCsgdLrhrexEomulfjQ=="],
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+mXNCNuFHNGYLrDqYWDeHH7kWCLCJFPpspx5PAAm+PD37PRMZJrTqDbaNK9qCghC1tdmT4/Lvilf/ewXHPlaKw=="],
 
-    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.0.16", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UXowfn2e94AwNk9UuoePRK+qiF15jZsssiyA15VK5GTtxpn6Sn+Z2QFciofxJczXXxM4abaf7qgx2OoJBt32VA=="],
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-+AU2HD7szuDsUdHue/E3OnF84B2ae/h7CGKpuIUHJntgoJ4kxf89oDvq2/xl8kDCn9cT76UUjgeZUgFYLRj+6Q=="],
 
-    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.0.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-U355elz4Z0AHSVqxfcglN09TGR86ov/GtYlliDknci2mmz6EWLiD3dTYnqJiwa4dYxqmuCDc/DvAL9rgb3YJiQ=="],
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KM70eV1tsEib1/tk+3TFxIdH84EaYlIg5KTQWAg+LB1N23nTQ7lL4Dnh1je6f6KW4tf21nmoMUqsh0xvMkQk8Q=="],
 
-    "lefthook-linux-x64": ["lefthook-linux-x64@2.0.16", "", { "os": "linux", "cpu": "x64" }, "sha512-7eAvBeWGAgjOKZ23OQbjJINLPImDIuDeX8dXOfk+aI6IFt2X6KCzRkp+ASUvGQtrPuNZQZT43EhW0/1jZU14ZQ=="],
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-6Bxmv+l7LiYq9W0IE6v2lmlRtBp6pisnlzhcouMGvH3rDwEGw11NAyRJZA3IPGEMAkIuhnlnVTUwAUzKomfJLg=="],
 
-    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.0.16", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-Fcd+E17ZkWGnRSQINb5gf+rNy2So5PYn5mBljiC31dl+TgWM8Wy46mSEGveHo7lKCO3q+DkmHIa50Qm58G03AQ=="],
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-ppJNK0bBSPLC8gqksRw5zI/0uLeMA5cK+hmZ4ofcuGNmdrN1dfl2Tx84fdeef0NcQY0ii9Y3j3icIKngIoid/g=="],
 
-    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.0.16", "", { "os": "openbsd", "cpu": "x64" }, "sha512-uL5nOkz8eBtQHped0/tB5X8clZ5kfnyjQrv1fpKbGAjeFHI2J+GmRqcn6Awq2IeuBbQvkyV6jDjpATyHBp5mCA=="],
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8k9lQsMYqQGu4spaQ8RNSOJidxIcOyfaoF2FPZhthtBfRV3cgVFGrsQ0hbIi5pvQRGUlCqYuCN79qauXHmnL3Q=="],
 
-    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.0.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-U61bNWzD6Vd2kjuJ7b4voPfTQ4mlBFOyTpCU3k/h0YjpKDQEFT1T5fDKkDothdnw/JVDSgrclIcfAY7Jyr/UIg=="],
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0WN+grrxt9zP9NGRcztoPXcz25tteem91rfLWgQFab+50csJ47zldlsB7/eOS/eHG5mUg5g5NPR4XefnXtjOcQ=="],
 
-    "lefthook-windows-x64": ["lefthook-windows-x64@2.0.16", "", { "os": "win32", "cpu": "x64" }, "sha512-dCHi2+hebhPI0LQUGRNjPMsGRyXhrTN3Y/b8M4HO8KVyGamKB3Yemf67ya81tZopDkxNVy5XUBXLYWKGhnAfLQ=="],
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XbO/5nAZQLpUn0tPpgCYfFBFJHnymSglQ73jD6wymNrR1j8I5EcXGlP6YcLhnZ83yzsdLC+gup+N6IqUeiyRdw=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -1171,7 +1171,7 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
-    "react-i18next": ["react-i18next@15.7.4", "", { "dependencies": { "@babel/runtime": "^7.27.6", "html-parse-stringify": "^3.0.1" }, "peerDependencies": { "i18next": ">= 23.4.0", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw=="],
+    "react-i18next": ["react-i18next@16.5.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 25.6.2", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "roxabi-boilerplate",
   "version": "0.1.0",
   "private": true,
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "prepare": "lefthook install",
     "dev": "turbo dev",
@@ -23,7 +26,7 @@
     "test:affected": "turbo run test --filter=...[origin/main]"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.3.14",
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",
     "@playwright/test": "^1.58.1",
@@ -35,7 +38,7 @@
     "@vitejs/plugin-react": "^5.1.3",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.0.0",
-    "lefthook": "^2.0.16",
+    "lefthook": "^2.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "turbo": "^2.8.2",

--- a/scripts/validate-translations.ts
+++ b/scripts/validate-translations.ts
@@ -10,7 +10,7 @@
  * - 1: Missing or extra keys found
  */
 
-import { readFile, readdir } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const LOCALES_DIR = join(import.meta.dirname, '../apps/web/src/locales')


### PR DESCRIPTION
## Summary

- **lefthook** 2.0.16 → 2.1.0 (minor, no breaking changes)
- **i18next** 24.2.2 → 25.8.1 (major, no impact on current usage)
- **react-i18next** 15.4.1 → 16.5.4 (major, no impact on current usage)
- **@biomejs/biome** 1.9.4 → 2.3.14 (major, config migrated via `biome migrate`)

### Biome 2 migration details
- Config schema updated to 2.3.14
- `organizeImports` moved to `assist.actions.source`
- `files.ignore` converted to `files.includes` with negation patterns
- New `noDocumentCookie` rule set to `warn` (intentional `document.cookie` usage for locale)
- Import ordering auto-fixed across 13 files (stricter sorting in v2)
- Added `biome-ignore` for intentional hook-in-try/catch pattern

## Test plan

- [x] `bun install` succeeds
- [x] `bun lint` passes (0 errors, 1 expected warning)
- [x] `bun typecheck` passes (5/5 packages)
- [x] `bun run test` passes (45/45 tests)
- [x] Pre-commit hook runs successfully
- [x] Pre-push hook runs successfully
- [ ] Language switching works in dev (`/en/dashboard` ↔ `/fr/dashboard`)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)