### PR TITLE
docs: fix outdated documentation across 5 files

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -9,14 +9,13 @@ description: Project structure, applications, packages and data flow in Roxabi B
 roxabi_boilerplate/
 ├── .env                    # Global environment variables
 ├── apps/
-│   ├── web/               # Frontend application
-│   ├── api/               # Backend API
-│   ├── docs/              # Documentation server (Fumadocs + Docker)
-│   └── packages/          # Shared code
-│       ├── ui/            # Shared UI components
-│       ├── config/        # Shared configurations
-│       └── types/         # Shared TypeScript types
-├── docs/                   # Documentation source (Markdown)
+│   ├── web/               # Frontend + Documentation (TanStack Start + Fumadocs)
+│   └── api/               # Backend API
+├── packages/               # Shared code
+│   ├── ui/                # Shared UI components
+│   ├── config/            # Shared configurations
+│   └── types/             # Shared TypeScript types
+├── docs/                   # Documentation content (MDX files)
 └── .claude/                # Claude Code configuration
 ```
 
@@ -47,11 +46,11 @@ Command-line interface generated from OpenAPI spec.
 - Multiple auth modes (env vars, config file, interactive login)
 - JSON output for scripting and AI parsing
 
-## Packages (`apps/packages/`)
+## Packages (`packages/`)
 
 Shared code used by applications.
 
-### UI (`apps/packages/ui`)
+### UI (`packages/ui`)
 
 Shared UI component library.
 
@@ -59,7 +58,7 @@ Shared UI component library.
 - Design system primitives
 - Exported from `@repo/ui`
 
-### Config (`apps/packages/config`)
+### Config (`packages/config`)
 
 Shared configurations.
 
@@ -67,7 +66,7 @@ Shared configurations.
 - Biome configs
 - Exported from `@repo/config`
 
-### Types (`apps/packages/types`)
+### Types (`packages/types`)
 
 Shared TypeScript type definitions.
 
@@ -75,20 +74,17 @@ Shared TypeScript type definitions.
 - API contracts
 - Exported from `@repo/types`
 
-## Documentation (`apps/docs/`)
+## Documentation
 
-Documentation server as a monorepo app.
+Documentation is integrated into `apps/web` using Fumadocs v16 with TanStack Start.
 
-- Fumadocs-powered server (Next.js)
-- Runs in Docker container
-- Port configurable via `.env` (`DOCS_PORT`)
-- MDX content in `apps/docs/content/`
+- MDX content lives in `docs/` at the repo root
+- Fumadocs renders docs at `/docs/*` routes
+- Single dev server for both app and documentation
 
 ```bash
 # Start documentation server
 bun docs
-# or
-docker compose -f apps/docs/docker-compose.yml up
 ```
 
 ## Data Flow
@@ -101,8 +97,8 @@ docker compose -f apps/docs/docker-compose.yml up
                            │                   │
                            ▼                   ▼
                     ┌─────────────┐     ┌─────────────┐
-                    │   apps/     │     │  Database   │
-                    │  packages/  │     │             │
+                    │  packages/  │     │  Database   │
+                    │             │     │             │
                     └─────────────┘     └─────────────┘
 ```
 
@@ -114,11 +110,11 @@ TurboRepo handles:
 - Dependency-aware builds
 - Caching for faster rebuilds
 
-Build order: `apps/packages/* → apps/*`
+Build order: `packages/* → apps/*`
 
 Workspaces configuration:
 ```json
 {
-  "workspaces": ["apps/*", "apps/packages/*"]
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -217,9 +217,6 @@ cp .env.example .env
 ```bash
 # Create the database
 createdb my_project_dev
-
-# Apply migrations (when configured)
-bun db:migrate
 ```
 
 ## 9. Run the Project
@@ -236,9 +233,9 @@ bun --filter @repo/api dev
 ## 10. Verify Installation
 
 - Frontend: http://localhost:3000
-- API: http://localhost:3001
-- API Docs (Swagger): http://localhost:3001/docs
-- Documentation: http://localhost:3002 (run `bun docs` first)
+- API: http://localhost:4000
+- API Docs (Swagger): http://localhost:4000/docs
+- Documentation: http://localhost:3000/docs (served by `bun docs`)
 
 ## Useful Commands
 
@@ -249,9 +246,9 @@ bun --filter @repo/api dev
 | `bun lint` | Lint with Biome |
 | `bun format` | Format with Biome |
 | `bun typecheck` | TypeScript type checking |
-| `bun test` | Run all tests |
+| `bun run test` | Run all tests (via turbo + vitest) |
 | `bun test:coverage` | Tests with coverage |
-| `bun docs` | Start documentation server (Docker) |
+| `bun docs` | Start documentation server (runs apps/web) |
 
 ## Next Steps
 

--- a/docs/guides/i18n.mdx
+++ b/docs/guides/i18n.mdx
@@ -10,7 +10,7 @@ This guide explains how to work with translations in the Roxabi application.
 The i18n system uses [i18next](https://www.i18next.com/) with the following structure:
 
 ```
-apps/web/
+apps/web/src/
 ├── lib/i18n/           # i18n configuration and hooks
 │   ├── types.ts        # Locale and namespace types
 │   ├── hooks.ts        # React hooks (useTranslation, useLocale)
@@ -39,7 +39,7 @@ apps/web/
 
 ### 2. Add the Key to All Locales
 
-Add the key to both `locales/en/{namespace}.json` and `locales/fr/{namespace}.json`:
+Add the key to both `src/locales/en/{namespace}.json` and `src/locales/fr/{namespace}.json`:
 
 ```json
 // locales/en/common.json
@@ -81,8 +81,8 @@ Create the namespace file in each locale folder:
 
 ```bash
 # Create files
-touch apps/web/locales/en/billing.json
-touch apps/web/locales/fr/billing.json
+touch apps/web/src/locales/en/billing.json
+touch apps/web/src/locales/fr/billing.json
 ```
 
 Add initial content:
@@ -95,7 +95,7 @@ Add initial content:
 
 ### 2. Update Types
 
-Add the namespace to `apps/web/lib/i18n/types.ts`:
+Add the namespace to `apps/web/src/lib/i18n/types.ts`:
 
 ```typescript
 export const NAMESPACES = ['common', 'auth', 'dashboard', 'settings', 'billing'] as const
@@ -114,7 +114,7 @@ bun run i18n:validate
 ### 1. Create Locale Folder
 
 ```bash
-mkdir apps/web/locales/de
+mkdir apps/web/src/locales/de
 ```
 
 ### 2. Copy and Translate Files
@@ -122,12 +122,12 @@ mkdir apps/web/locales/de
 Copy all JSON files from `en/` and translate them:
 
 ```bash
-cp apps/web/locales/en/*.json apps/web/locales/de/
+cp apps/web/src/locales/en/*.json apps/web/src/locales/de/
 ```
 
 ### 3. Update Types
 
-Add the locale to `apps/web/lib/i18n/types.ts`:
+Add the locale to `apps/web/src/lib/i18n/types.ts`:
 
 ```typescript
 export const LOCALES = ['en', 'fr', 'de'] as const

--- a/docs/vision.mdx
+++ b/docs/vision.mdx
@@ -161,14 +161,13 @@ A CLI generated from OpenAPI specs enables AI agents to interact with the SaaS A
 roxabi_boilerplate/
 ├── .env                    # Global environment variables
 ├── apps/
-│   ├── web/               # Frontend (TanStack Start)
-│   ├── api/               # Backend (NestJS + Fastify)
-│   ├── docs/              # Documentation server (Fumadocs + Docker)
-│   └── packages/          # Shared code
-│       ├── ui/            # Shared UI (Shadcn/UI)
-│       ├── config/        # Shared configurations
-│       └── types/         # Shared TypeScript types
-├── docs/                   # Documentation source (Markdown)
+│   ├── web/               # Frontend + Documentation (TanStack Start + Fumadocs)
+│   └── api/               # Backend (NestJS + Fastify)
+├── packages/               # Shared code
+│   ├── ui/                # Shared UI components
+│   ├── config/            # Shared configurations
+│   └── types/             # Shared TypeScript types
+├── docs/                   # Documentation content (MDX files)
 └── .claude/                # Claude Code configuration
 ```
 
@@ -203,8 +202,8 @@ META Organization (super admin)
                            │                   │
                            ▼                   ▼
                     ┌─────────────┐     ┌─────────────┐
-                    │    apps/    │     │  PostgreSQL │
-                    │  packages/  │     │   (RLS)     │
+                    │  packages/  │     │  PostgreSQL │
+                    │             │     │   (RLS)     │
                     └─────────────┘     └─────────────┘
 ```
 
@@ -283,23 +282,23 @@ To be prioritized later:
 
 ### Decided
 
-| Category | Choice |
-|----------|--------|
-| Package manager | Bun |
-| Language | TypeScript 5.x (strict) |
-| Linting | Biome |
-| Monorepo | TurboRepo |
-| Frontend | TanStack Start |
-| Backend | NestJS + Fastify |
-| CI/CD | GitHub Actions |
-| Database | PostgreSQL |
-| ORM | Drizzle |
-| Auth | Better Auth |
-| UI | Shadcn/UI |
-| Tests | Vitest + Playwright |
-| Monitoring | PostHog |
-| API Style | REST + OpenAPI |
-| Multi-tenant | Row-Level Security |
+| Category | Choice | Status |
+|----------|--------|--------|
+| Package manager | Bun | Implemented |
+| Language | TypeScript 5.x (strict) | Implemented |
+| Linting | Biome | Implemented |
+| Monorepo | TurboRepo | Implemented |
+| Frontend | TanStack Start | Implemented |
+| Backend | NestJS + Fastify | Planned |
+| CI/CD | GitHub Actions | Implemented |
+| Database | PostgreSQL | Planned |
+| ORM | Drizzle | Planned |
+| Auth | Better Auth | Planned |
+| UI | Shadcn/UI | Planned |
+| Tests | Vitest + Playwright | Implemented |
+| Monitoring | PostHog | Planned |
+| API Style | REST + OpenAPI | Planned |
+| Multi-tenant | Row-Level Security | Planned |
 
 ### Abstracted (Implementation at Deploy)
 


### PR DESCRIPTION
## Summary

- **architecture.mdx**: Fix packages path (`apps/packages/` → `packages/`), remove non-existent `apps/docs/` section, update docs section for Fumadocs integration in `apps/web`, fix workspaces config
- **getting-started.mdx**: Fix API port (`3001` → `4000`), test command (`bun test` → `bun run test`), remove non-existent `db:migrate` command, update docs URL
- **configuration.mdx**: Fix `API_URL` default (`3001` → `4000`)
- **guides/i18n.mdx**: Fix all file paths to include `src/` directory
- **vision.mdx**: Fix monorepo structure, add implementation status column to technical decisions table

Closes #30

## Test plan

- [ ] Verify `bun docs` starts and all pages render correctly
- [ ] Check architecture page shows correct monorepo structure
- [ ] Check getting-started page has correct ports and commands
- [ ] Check i18n guide paths match actual file locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)