### PR TITLE
ci: add staging branch and on-demand preview deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   push:
-    branches: [main]
+    branches: [main, staging]
   workflow_call:
 
 permissions:
@@ -220,6 +220,7 @@ jobs:
       needs.build.result == 'success' &&
       (
         github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/staging' ||
         contains(github.event.pull_request.labels.*.name, 'e2e') ||
         needs.check-e2e-paths.outputs.should-run == 'true'
       )

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,115 @@
+name: Deploy Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which app to deploy"
+        required: true
+        type: choice
+        options:
+          - both
+          - web
+          - api
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: "1.3.9"
+  NODE_VERSION: "24"
+
+jobs:
+  deploy-web:
+    name: Deploy Web Preview
+    runs-on: ubuntu-latest
+    if: inputs.target == 'web' || inputs.target == 'both'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+
+      - name: Build
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+
+      - name: Deploy
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+
+      - name: Summary
+        run: echo "### Web Preview\n${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-api:
+    name: Deploy API Preview
+    runs-on: ubuntu-latest
+    if: inputs.target == 'api' || inputs.target == 'both'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_API }}
+
+      - name: Build
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_API }}
+
+      - name: Deploy
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_API }}
+
+      - name: Summary
+        run: echo "### API Preview\n${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ When detecting a large workload (3+ complex tasks, migrations, or multi-componen
 **If Tier M or L, create worktree BEFORE coding:**
 
 ```bash
-git worktree add ../roxabi-XXX -b feat/XXX-slug
+git worktree add ../roxabi-XXX -b feat/XXX-slug staging
 cd ../roxabi-XXX
 ```
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -5,12 +5,17 @@ description: Workflow conventions, branching strategy, and contribution guidelin
 
 ## Branching Strategy
 
-We use **GitHub Flow** - a simple, trunk-based workflow optimized for continuous delivery.
+We use a **staging-based flow** — feature branches merge into `staging` for integration, then `staging` is promoted to `main` for production deployment.
 
-### Main Branch
+### Branches
 
-- `main` is always production-ready
-- All changes go through Pull Requests
+| Branch | Purpose | Auto-deploys? |
+|--------|---------|---------------|
+| `main` | Production — always deployable | Yes (Vercel) |
+| `staging` | Integration — default PR target | No (use Deploy Preview action) |
+
+- All feature/fix PRs target `staging`
+- Only `hotfix/*` branches may target `main` directly
 - Protected with required reviews and status checks
 
 ### Branch Naming
@@ -24,15 +29,29 @@ We use **GitHub Flow** - a simple, trunk-based workflow optimized for continuous
 
 ### Workflow
 
+**Normal flow:**
+
 ```
 1. Pick a GitHub Issue
-2. Create feature branch from main
+2. Create feature branch from staging
 3. Implement changes (with tests)
-4. Open Pull Request
+4. Open Pull Request targeting staging
 5. Pass all quality gates
 6. Get review approval
-7. Merge to main
-8. Auto-deploy to production
+7. Merge to staging
+8. (Optional) Trigger Deploy Preview from Actions tab
+9. When ready, promote staging → main for production deploy
+```
+
+**Hotfix flow:**
+
+```
+1. Create hotfix/* branch from main
+2. Implement minimal fix
+3. Open Pull Request targeting main
+4. Pass all quality gates + review
+5. Merge to main → auto-deploys to production
+6. Cherry-pick or merge fix back into staging
 ```
 
 ---
@@ -101,7 +120,7 @@ ci: add coverage reporting to pipeline
 
 ### Before Opening a PR
 
-- [ ] Branch is up-to-date with `main`
+- [ ] Branch is up-to-date with `staging` (or `main` for hotfixes)
 - [ ] All tests pass locally (`bun test`)
 - [ ] Linting passes (`bun lint`)
 - [ ] Types check (`bun typecheck`)
@@ -140,24 +159,30 @@ All PRs must pass before merge:
 
 ### After Merge
 
-When a PR is merged to `main`, deployment happens automatically:
+**Merge to `staging`:**
+- CI runs on the push to staging
+- No automatic deployment — use the **Deploy Preview** GitHub Action to create on-demand preview URLs
 
-1. **Web** (TanStack Start) — Vercel detects the push and deploys
-2. **API** (NestJS) — Vercel detects the push and deploys (zero-config NestJS support)
-3. GitHub Actions runs CI and reports status on the commit
-
-If something breaks, roll back via the Vercel dashboard (Deployments &gt; Promote previous). See the [Deployment Guide](/docs/guides/deployment) for details.
+**Merge to `main`:**
+- Vercel auto-deploys both web and API to production
+- If something breaks, roll back via the Vercel dashboard (Deployments &gt; Promote previous). See the [Deployment Guide](/docs/guides/deployment) for details.
 
 ---
 
 ## Branch Protection
 
-The `main` branch is protected with:
+**`main` branch:**
 
 - Required pull request reviews (1 minimum)
 - Required status checks (CI must pass)
 - Dismiss stale approvals on new commits
 - Require conversation resolution
+- No direct pushes
+- Only `hotfix/*` and `staging` merges allowed
+
+**`staging` branch:**
+
+- Required status checks (CI must pass)
 - No direct pushes
 
 ---

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -5,13 +5,12 @@ description: Deploy Roxabi on Vercel — both web and API on one platform
 
 ## Overview
 
-Roxabi uses a push-to-deploy architecture with **Vercel** as the single deployment platform for both the web app and API.
+Roxabi uses a **staging-based** deployment architecture with **Vercel** as the single platform for both the web app and API.
 
 ```
-Push to main
-  -> GitHub Actions CI (lint, typecheck, test)
-  -> Vercel auto-deploys web app (TanStack Start)
-  -> Vercel auto-deploys API (NestJS — zero-config support)
+Feature branch → PR to staging → CI runs
+                                → (optional) Deploy Preview via GitHub Actions
+staging → PR to main → CI runs → Vercel auto-deploys to production
 ```
 
 | Component | Platform | Details |
@@ -21,6 +20,57 @@ Push to main
 | Database | Neon | Serverless PostgreSQL, not managed by Vercel |
 
 No Docker is needed for deployment. Docker configurations (Dockerfiles, `docker-compose.prod.yml`, Nginx configs, `deploy/`) remain in the repo for local development only.
+
+---
+
+## Branch Strategy
+
+| Flow | Branch path | Deploys? |
+|------|-------------|----------|
+| **Normal** | `feat/*` → PR to `staging` → PR to `main` | Only `main` merges auto-deploy |
+| **Hotfix** | `hotfix/*` → PR to `main` | Auto-deploys immediately |
+
+- `staging` is the default integration branch — all feature PRs target it
+- Merging to `staging` does **not** trigger a Vercel deploy
+- Use the **Deploy Preview** GitHub Action for on-demand preview URLs from staging
+- Only merges to `main` trigger production auto-deploys
+
+---
+
+## Preview Deploys
+
+Preview deploys are **manual only**, triggered via the GitHub Actions tab.
+
+### How to trigger
+
+1. Go to **Actions** → **Deploy Preview**
+2. Click **Run workflow**
+3. Select the branch (typically `staging`)
+4. Choose a target: `web`, `api`, or `both`
+5. Click **Run workflow**
+
+The workflow builds and deploys a Vercel preview. The preview URL appears in the **workflow run summary**.
+
+### When to use
+
+- Before promoting `staging` → `main`, to verify the integration build
+- To share a preview URL with stakeholders for review
+- To smoke-test a specific branch without deploying to production
+
+---
+
+## GitHub Actions Secrets
+
+The **Deploy Preview** workflow requires these repository secrets:
+
+| Secret | Description | Where to find |
+|--------|-------------|---------------|
+| `VERCEL_TOKEN` | Vercel personal access token | [vercel.com/account/tokens](https://vercel.com/account/tokens) |
+| `VERCEL_ORG_ID` | Vercel team/org ID | `.vercel/project.json` → `orgId` (after `vercel link`) |
+| `VERCEL_PROJECT_ID_WEB` | Vercel project ID for web | `apps/web/.vercel/project.json` → `projectId` |
+| `VERCEL_PROJECT_ID_API` | Vercel project ID for API | `apps/api/.vercel/project.json` → `projectId` |
+
+Add them at **Settings** → **Secrets and variables** → **Actions** → **New repository secret**.
 
 ---
 
@@ -225,7 +275,7 @@ Both projects use `ignoreCommand` in `vercel.json` to only trigger Vercel builds
 "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]"
 ```
 
-Manual preview deploys can still be triggered via the CLI:
+Preview deploys are handled via the **Deploy Preview** GitHub Action (see [Preview Deploys](#preview-deploys) above). You can also trigger them locally via the CLI:
 
 ```bash
 cd apps/web && vercel        # Preview deploy

--- a/docs/processes/dev-process.mdx
+++ b/docs/processes/dev-process.mdx
@@ -23,6 +23,8 @@ Otherwise ───────────────────────�
 | **M** | Feature Light | 3-10 files, local arch | Worktree + light review |
 | **S** | Quick Fix | ≤3 files, no arch, no risk | Direct branch + PR |
 
+> **Branch Strategy:** `staging` is the default integration branch. All feature and fix branches are created from `staging` and PRs target `staging`. Only `hotfix/*` branches may target `main` directly. Merges to `main` trigger production deploys; merges to `staging` do not auto-deploy (use the **Deploy Preview** GitHub Action for on-demand previews).
+
 ---
 
 ## Development Checklist
@@ -92,7 +94,7 @@ Follow this order:
 
 ```bash
 # 1. Create branch
-git checkout -b fix/XXX-description
+git checkout -b fix/XXX-description staging
 
 # 2. Check changes
 git status
@@ -137,7 +139,7 @@ For Tier M and L tasks, consider using **Agent Teams** to parallelize work acros
 ### M.2 — Create Worktree
 
 ```bash
-git worktree add ../roxabi-XXX -b feat/XXX-slug
+git worktree add ../roxabi-XXX -b feat/XXX-slug staging
 cd ../roxabi-XXX
 ```
 
@@ -187,7 +189,7 @@ git worktree remove ../roxabi-XXX
 ### L.2 — Create Worktree
 
 ```bash
-git worktree add ../roxabi-XXX -b feat/XXX-slug
+git worktree add ../roxabi-XXX -b feat/XXX-slug staging
 cd ../roxabi-XXX
 ```
 
@@ -203,7 +205,7 @@ cd ../roxabi-XXX
 4. Update documentation
 
 ### L.5 — Self-Review
-- Review all changes: `git diff main...HEAD`
+- Review all changes: `git diff staging...HEAD`
 - Verify all checklist items
 - Run full test suite: `bun test`
 


### PR DESCRIPTION
## Summary
- Introduce `staging` as the default integration branch — feature PRs now target staging instead of main
- Add **Deploy Preview** GitHub Actions workflow (`workflow_dispatch`) for on-demand Vercel preview deploys of web, API, or both
- Extend CI to run on PRs and pushes to both `main` and `staging`, including E2E tests on staging
- Update all developer docs (dev-process, contributing, deployment, CLAUDE.md) to reflect the staging-based branching strategy and hotfix flow

## Test Plan
- [ ] Verify CI workflow syntax: `gh workflow list` shows both CI and Deploy Preview workflows
- [ ] Open a test PR targeting staging — CI should run all jobs (lint, typecheck, test, build)
- [ ] Verify E2E job condition includes `refs/heads/staging`
- [ ] After adding GitHub Actions secrets, trigger Deploy Preview from Actions tab — verify preview URL in step summary
- [ ] Merge to staging should NOT trigger Vercel auto-deploy
- [ ] Merge to main should still auto-deploy to production (unchanged)
- [ ] Search docs for stale references to "GitHub Flow" or "branch from main"

## Post-Merge Manual Steps
1. `git push origin main:staging` — create staging branch from main
2. Set default branch to `staging` in GitHub Settings → General
3. Configure branch protection for `main` (require PR + CI + 1 review) and `staging` (require CI)
4. Add 4 GitHub Actions secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID_WEB`, `VERCEL_PROJECT_ID_API`

Closes #114

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`