### PR TITLE
chore(deps): monorepo hygiene fixes from health audit

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,6 @@
     "@repo/config": "workspace:*",
     "@types/node": "^25.2.0",
     "drizzle-kit": "^0.31.8",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,7 +78,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.0.4",
     "jsdom": "^27.0.0",
-    "typescript": "^5.7.2",
+    "typescript": "^5.9.3",
     "vite": "^7.1.7",
     "vitest": "^4.0.18",
     "web-vitals": "^5.1.0"

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@repo/config": "workspace:*",
         "@types/node": "^25.2.0",
         "drizzle-kit": "^0.31.8",
-        "typescript": "^5.7.0",
+        "typescript": "^5.9.3",
       },
     },
     "apps/web": {
@@ -124,7 +124,7 @@
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.4",
         "jsdom": "^27.0.0",
-        "typescript": "^5.7.2",
+        "typescript": "^5.9.3",
         "vite": "^7.1.7",
         "vitest": "^4.0.18",
         "web-vitals": "^5.1.0",
@@ -149,7 +149,6 @@
       "name": "@repo/ui",
       "version": "0.1.0",
       "dependencies": {
-        "@repo/types": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "culori": "^4.0.2",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,8 +9,7 @@
     ".": "./src/index.ts",
     "./vitest": "./src/vitest.ts",
     "./tsconfig": "./tsconfig.json",
-    "./tsconfig.base": "./tsconfig.base.json",
-    "./biome": "./biome.json"
+    "./tsconfig.base": "./tsconfig.base.json"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@repo/types": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "culori": "^4.0.2",


### PR DESCRIPTION
## Summary

- Remove phantom `@repo/types` dependency from `@repo/ui` (declared but never imported)
- Remove dead `./biome` export from `@repo/config` (no `biome.json` exists in that package)
- Align TypeScript version to `^5.9.3` across all workspaces (`apps/web` was `^5.7.2`, `apps/api` was `^5.7.0`)

Closes #119

## Test plan

- [x] `bun install` succeeds
- [x] `bun typecheck` passes (7/7 packages)
- [x] `bun turbo test` passes (all 3 test suites)
- [x] Pre-commit hooks pass (biome + commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)