### PR TITLE
fix(web): wrap register terms label for inline text flow

### DIFF
--- a/apps/web/src/routes/register.tsx
+++ b/apps/web/src/routes/register.tsx
@@ -216,18 +216,20 @@ function RegisterPage() {
             disabled={loading}
           />
           <Label htmlFor="accept-terms" className="text-sm font-normal leading-snug cursor-pointer">
-            {m.auth_accept_privacy_prefix()}{' '}
-            <Link
-              to="/legal/confidentialite"
-              className="underline hover:text-foreground"
-              target="_blank"
-            >
-              {m.auth_accept_privacy_policy()}
-            </Link>{' '}
-            {m.auth_accept_terms_and()}{' '}
-            <Link to="/legal/cgu" className="underline hover:text-foreground" target="_blank">
-              {m.auth_accept_terms_of_service()}
-            </Link>
+            <span>
+              {m.auth_accept_privacy_prefix()}{' '}
+              <Link
+                to="/legal/confidentialite"
+                className="underline hover:text-foreground"
+                target="_blank"
+              >
+                {m.auth_accept_privacy_policy()}
+              </Link>{' '}
+              {m.auth_accept_terms_and()}{' '}
+              <Link to="/legal/cgu" className="underline hover:text-foreground" target="_blank">
+                {m.auth_accept_terms_of_service()}
+              </Link>
+            </span>
           </Label>
         </div>
         <Button type="submit" className="w-full" disabled={loading || !acceptedTerms}>


### PR DESCRIPTION
## Summary
- Fix registration page terms label rendering incorrectly in French (and all locales)
- The `Label` component's default `flex` layout caused each text node and link to render as separate flex items on different lines
- Wrapping content in a `<span>` ensures the sentence flows inline as a single unit

## Test plan
- [ ] Visit `/fr/register` and verify the terms checkbox label reads as one sentence
- [ ] Verify `/en/register` also renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)