### PR TITLE
fix(ci): revert upload-artifact to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
         run: bun test:e2e --project=chromium --reporter=list --reporter=html
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: playwright-report
@@ -445,7 +445,7 @@ jobs:
         run: bun test:e2e --shard=${{ matrix.shard }}
 
       - name: Upload blob report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: blob-report-${{ strategy.job-index }}
@@ -487,7 +487,7 @@ jobs:
         run: bunx playwright merge-reports --reporter html all-blob-reports
 
       - name: Upload merged report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-merged
           path: playwright-report/


### PR DESCRIPTION
## Summary

- Reverts `actions/upload-artifact` from v7 back to v6 in CI workflow
- v7 does not exist yet — PR #301 incorrectly bumped it, causing E2E job failures with: `Unable to resolve action actions/upload-artifact@v7`

## Test plan

- [ ] CI E2E jobs should pass (upload-artifact@v6 resolves correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)