### PR TITLE
fix(e2e): correct API entrypoint path in Playwright config

### DIFF
--- a/packages/playwright-config/base.ts
+++ b/packages/playwright-config/base.ts
@@ -53,7 +53,7 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
     {
       // API server (backend) — for full-stack E2E tests
       // Only start in CI or if explicitly requested (local dev uses 'bun run dev')
-      command: process.env.CI ? 'node apps/api/dist/main.js' : 'bun run --cwd apps/api dev',
+      command: process.env.CI ? 'node apps/api/dist/index.js' : 'bun run --cwd apps/api dev',
       url: 'http://localhost:4000',
       reuseExistingServer: !process.env.CI,
       timeout: 120000,


### PR DESCRIPTION
## Summary
- Fix E2E CI failures caused by Playwright looking for `dist/main.js` when NestJS builds `dist/index.js`
- The entryFile was renamed from `main` to `index` in commit 4ef9ad1 but the Playwright webServer command was not updated

## Test Plan
- [ ] CI E2E tests pass (previously failing with `MODULE_NOT_FOUND`)
- [ ] Local `bun run dev` still works (dev path unchanged)

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`