### PR TITLE
feat(talks): add Lyra companion with 7 evolving variants (#452)

### DIFF
--- a/apps/web/src/components/presentation/lyra-story/LyraCompanion.tsx
+++ b/apps/web/src/components/presentation/lyra-story/LyraCompanion.tsx
@@ -1,0 +1,413 @@
+import { cn, useReducedMotion } from '@repo/ui'
+import { useId } from 'react'
+import { BlobVariant } from './variants/BlobVariant'
+import { PokemonVariant } from './variants/PokemonVariant'
+import { RpgCanvasVariant } from './variants/RpgCanvasVariant'
+import { SilhouetteVariant } from './variants/SilhouetteVariant'
+import { TamagotchiVariant } from './variants/TamagotchiVariant'
+
+export type LyraVariant =
+  | 'quantum'
+  | 'constellation'
+  | 'rpg-canvas'
+  | 'tamagotchi'
+  | 'silhouette'
+  | 'blob'
+  | 'pokemon'
+
+type LyraCompanionProps = {
+  /** 0-16: evolution stage */
+  stage: number
+  /** Visual variant to render */
+  variant: LyraVariant
+  /** Size in px */
+  size?: number
+  className?: string
+}
+
+export function LyraCompanion({ stage, variant, size = 80, className }: LyraCompanionProps) {
+  switch (variant) {
+    case 'quantum':
+      return <QuantumVariant stage={stage} size={size} className={className} />
+    case 'constellation':
+      return <ConstellationVariant stage={stage} size={size} className={className} />
+    case 'rpg-canvas':
+      return <RpgCanvasVariant stage={stage} size={size} className={className} />
+    case 'tamagotchi':
+      return <TamagotchiVariant stage={stage} size={size} className={className} />
+    case 'silhouette':
+      return <SilhouetteVariant stage={stage} size={size} className={className} />
+    case 'blob':
+      return <BlobVariant stage={stage} size={size} className={className} />
+    case 'pokemon':
+      return <PokemonVariant stage={stage} size={size} className={className} />
+  }
+}
+
+// ─── Variant: Quantum Orbital Evolution ─────────────────────────────────────
+
+function QuantumVariant({
+  stage,
+  size,
+  className,
+}: {
+  stage: number
+  size: number
+  className?: string
+}) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const t = stage / 16
+
+  const coreRadius = lerp(1, 6, Math.min(t * 2, 1))
+  const coreOpacity = lerp(0.2, 1, Math.min(t * 1.5, 1))
+  const glowRadius = lerp(0, 18, t)
+  const glowOpacity = lerp(0, 0.3, t)
+  const ringCount = Math.min(Math.floor(t * 5), 3)
+  const electronCount = Math.min(Math.floor(t * 7), 5)
+  const auraOpacity = t > 0.5 ? lerp(0, 0.15, (t - 0.5) * 2) : 0
+  const showLetter = stage >= 9
+  const letterOpacity = stage >= 9 ? lerp(0, 1, (stage - 9) / 7) : 0
+  const isGlitching = stage === 2
+  const isSerene = stage === 16
+  const isPeak = stage === 14
+  const satelliteCount = stage >= 11 ? Math.min(stage - 10, 6) : 0
+  const animate = !reducedMotion
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={cn(
+        'transition-all duration-1000',
+        isGlitching && animate && 'lyra-glitch',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id={`lc-glow-${uid}`} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#2D7FF9" stopOpacity={glowOpacity} />
+          <stop offset="100%" stopColor="#8B5CF6" stopOpacity="0" />
+        </radialGradient>
+        <filter id={`lc-blur-${uid}`} x="-100%" y="-100%" width="300%" height="300%">
+          <feGaussianBlur stdDeviation="3" />
+        </filter>
+        <filter id={`lc-soft-${uid}`} x="-200%" y="-200%" width="500%" height="500%">
+          <feGaussianBlur stdDeviation="6" />
+        </filter>
+      </defs>
+
+      {auraOpacity > 0 && (
+        <circle
+          cx="50"
+          cy="50"
+          r="42"
+          fill="none"
+          stroke="#8B5CF6"
+          strokeWidth="0.5"
+          opacity={auraOpacity}
+          filter={`url(#lc-soft-${uid})`}
+          className={cn(animate && isPeak && 'lyra-aura-peak')}
+        />
+      )}
+
+      <circle
+        cx="50"
+        cy="50"
+        r={glowRadius}
+        fill={`url(#lc-glow-${uid})`}
+        className="transition-all duration-1000"
+      />
+
+      {ringCount >= 1 && (
+        <ellipse
+          cx="50"
+          cy="50"
+          rx={lerp(20, 35, t)}
+          ry={lerp(8, 12, t)}
+          fill="none"
+          stroke="#2D7FF9"
+          strokeWidth={lerp(0.3, 0.8, t)}
+          opacity={lerp(0.2, 0.6, t)}
+          transform="rotate(-35, 50, 50)"
+          className={cn(animate && 'lyra-ring1')}
+          style={{ transformOrigin: '50px 50px' }}
+        />
+      )}
+      {ringCount >= 2 && (
+        <ellipse
+          cx="50"
+          cy="50"
+          rx={lerp(20, 35, t)}
+          ry={lerp(8, 12, t)}
+          fill="none"
+          stroke="#8B5CF6"
+          strokeWidth={lerp(0.3, 0.6, t)}
+          opacity={lerp(0.2, 0.5, t)}
+          transform="rotate(55, 50, 50)"
+          className={cn(animate && 'lyra-ring2')}
+          style={{ transformOrigin: '50px 50px' }}
+        />
+      )}
+      {ringCount >= 3 && (
+        <ellipse
+          cx="50"
+          cy="50"
+          rx={lerp(20, 35, t)}
+          ry={lerp(6, 10, t)}
+          fill="none"
+          stroke="#8B5CF6"
+          strokeWidth="0.4"
+          opacity="0.2"
+          className={cn(animate && 'lyra-ring3')}
+          style={{ transformOrigin: '50px 50px' }}
+        />
+      )}
+
+      {Array.from({ length: electronCount }).map((_, i) => {
+        const angle = (i * 360) / electronCount
+        const orbitR = lerp(18, 32, t)
+        const ex = 50 + orbitR * Math.cos((angle * Math.PI) / 180)
+        const ey = 50 + orbitR * Math.sin((angle * Math.PI) / 180) * 0.4
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static electron positions
+          <circle
+            key={i}
+            cx={ex}
+            cy={ey}
+            r={lerp(1, 2.5, t)}
+            fill={i % 2 === 0 ? '#2D7FF9' : '#8B5CF6'}
+            opacity={lerp(0.3, 0.8, t)}
+            filter={`url(#lc-blur-${uid})`}
+            className={cn(animate && `lyra-electron-${(i % 3) + 1}`)}
+            style={{ transformOrigin: '50px 50px' }}
+          />
+        )
+      })}
+
+      {Array.from({ length: satelliteCount }).map((_, i) => {
+        const angle = i * 60 + 30
+        const sx = 50 + 40 * Math.cos((angle * Math.PI) / 180)
+        const sy = 50 + 40 * Math.sin((angle * Math.PI) / 180)
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static satellite positions
+          <circle
+            key={i}
+            cx={sx}
+            cy={sy}
+            r="1.5"
+            fill={i % 2 === 0 ? '#2D7FF9' : '#8B5CF6'}
+            opacity="0.5"
+            className={cn(animate && 'lyra-satellite')}
+          />
+        )
+      })}
+
+      <circle
+        cx="50"
+        cy="50"
+        r={coreRadius * 2}
+        fill="#2D7FF9"
+        opacity={coreOpacity * 0.15}
+        filter={`url(#lc-soft-${uid})`}
+        className={cn('transition-all duration-1000', animate && !isSerene && 'lyra-core-pulse')}
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r={coreRadius}
+        fill="white"
+        opacity={coreOpacity}
+        filter={`url(#lc-blur-${uid})`}
+        className="transition-all duration-1000"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r={coreRadius * 0.5}
+        fill="#8B5CF6"
+        opacity={coreOpacity}
+        className="transition-all duration-1000"
+      />
+
+      {showLetter && (
+        <text
+          x="50"
+          y="54"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={lerp(8, 14, (stage - 9) / 7)}
+          fontWeight="bold"
+          className="transition-all duration-1000"
+          opacity={letterOpacity}
+          style={{ fill: '#e0e0ff', filter: `url(#lc-blur-${uid})` }}
+        >
+          L
+        </text>
+      )}
+
+      {stage >= 13 && (
+        <rect
+          x="6"
+          y="6"
+          width="88"
+          height="88"
+          rx="4"
+          fill="none"
+          stroke="#8B5CF6"
+          strokeWidth="0.5"
+          strokeDasharray={stage >= 14 ? 'none' : '4 4'}
+          opacity={lerp(0.2, 0.5, (stage - 13) / 3)}
+          className="transition-all duration-1000"
+        />
+      )}
+
+      {stage >= 7 && (
+        <path
+          d={`M 20 75 Q 30 ${70 - t * 5} 40 75 Q 50 ${80 + t * 5} 60 75 Q 70 ${70 - t * 5} 80 75`}
+          fill="none"
+          stroke="#2D7FF9"
+          strokeWidth="0.8"
+          opacity={lerp(0, 0.5, (stage - 7) / 9)}
+          className={cn(animate && 'lyra-wave')}
+        />
+      )}
+    </svg>
+  )
+}
+
+// ─── Variant: Constellation ─────────────────────────────────────────────────
+
+function ConstellationVariant({
+  stage,
+  size,
+  className,
+}: {
+  stage: number
+  size: number
+  className?: string
+}) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const t = stage / 16
+  const animate = !reducedMotion
+
+  const starCount = Math.min(Math.floor(t * 12) + 1, 12)
+  const lineCount = Math.max(0, Math.min(Math.floor(t * 10) - 1, 10))
+
+  const stars = [
+    { x: 50, y: 20 },
+    { x: 35, y: 40 },
+    { x: 65, y: 40 },
+    { x: 30, y: 55 },
+    { x: 70, y: 55 },
+    { x: 35, y: 70 },
+    { x: 65, y: 70 },
+    { x: 50, y: 50 },
+    { x: 20, y: 30 },
+    { x: 80, y: 30 },
+    { x: 45, y: 85 },
+    { x: 55, y: 85 },
+  ]
+
+  const lines: [number, number][] = [
+    [0, 1],
+    [0, 2],
+    [1, 3],
+    [2, 4],
+    [3, 5],
+    [4, 6],
+    [5, 6],
+    [1, 7],
+    [2, 7],
+    [0, 7],
+  ]
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={cn('transition-all duration-1000', className)}
+      aria-hidden="true"
+    >
+      <defs>
+        <filter id={`lc-star-${uid}`} x="-100%" y="-100%" width="300%" height="300%">
+          <feGaussianBlur stdDeviation="1.5" />
+        </filter>
+      </defs>
+
+      {lines.slice(0, lineCount).map(([a, b], i) => {
+        const from = stars[a]!
+        const to = stars[b]!
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static constellation lines
+          <line
+            key={i}
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke="#2D7FF9"
+            strokeWidth={lerp(0.3, 0.8, t)}
+            opacity={lerp(0.1, 0.4, t)}
+            className="transition-all duration-1000"
+          />
+        )
+      })}
+
+      {stars.slice(0, starCount).map((star, i) => {
+        const isVega = i === 0
+        const r = isVega ? lerp(1.5, 4, t) : lerp(0.5, 2, t)
+        const fill = i % 3 === 0 ? '#ffffff' : i % 3 === 1 ? '#2D7FF9' : '#8B5CF6'
+        return (
+          <g key={`${star.x}-${star.y}`}>
+            <circle
+              cx={star.x}
+              cy={star.y}
+              r={r * 3}
+              fill={fill}
+              opacity={lerp(0.03, isVega ? 0.15 : 0.08, t)}
+              filter={`url(#lc-star-${uid})`}
+            />
+            <circle
+              cx={star.x}
+              cy={star.y}
+              r={r}
+              fill={fill}
+              opacity={lerp(0.3, 1, t)}
+              className={cn(
+                'transition-all duration-1000',
+                animate && isVega && stage >= 8 && 'lyra-star-pulse'
+              )}
+            />
+          </g>
+        )
+      })}
+
+      {stage >= 9 && (
+        <text
+          x="50"
+          y="96"
+          textAnchor="middle"
+          fontSize="6"
+          fontFamily="monospace"
+          letterSpacing="3"
+          fill="#8B5CF6"
+          opacity={lerp(0, 0.6, (stage - 9) / 7)}
+          className="transition-all duration-1000"
+        >
+          LYRA
+        </text>
+      )}
+    </svg>
+  )
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}

--- a/apps/web/src/components/presentation/lyra-story/variants/BlobVariant.tsx
+++ b/apps/web/src/components/presentation/lyra-story/variants/BlobVariant.tsx
@@ -1,0 +1,266 @@
+import { cn, useReducedMotion } from '@repo/ui'
+import { useId } from 'react'
+
+type BlobVariantProps = {
+  stage: number
+  size: number
+  className?: string
+}
+
+// Organic blob that morphs from amorphous shape to humanoid silhouette
+// Uses SVG path interpolation between keyframe shapes
+export function BlobVariant({ stage, size, className }: BlobVariantProps) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const animate = !reducedMotion
+  const t = stage / 16
+
+  const path = interpolatePath(stage)
+  const color1 = `hsl(${lerp(220, 260, t)}, ${lerp(60, 80, t)}%, ${lerp(40, 55, t)}%)`
+  const color2 = `hsl(${lerp(240, 280, t)}, ${lerp(50, 70, t)}%, ${lerp(30, 45, t)}%)`
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={cn('transition-all duration-1000', className)}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={`blob-grad-${uid}`} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor={color1} />
+          <stop offset="100%" stopColor={color2} />
+        </linearGradient>
+        <radialGradient id={`blob-glow-${uid}`} cx="50%" cy="40%" r="50%">
+          <stop offset="0%" stopColor="#2D7FF9" stopOpacity={lerp(0, 0.4, t)} />
+          <stop offset="100%" stopColor="transparent" />
+        </radialGradient>
+        <filter id={`blob-blur-${uid}`} x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation={lerp(5, 1, t)} />
+        </filter>
+        <filter id={`blob-goo-${uid}`} x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
+          <feColorMatrix
+            in="blur"
+            type="matrix"
+            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
+            result="goo"
+          />
+          <feBlend in="SourceGraphic" in2="goo" />
+        </filter>
+      </defs>
+
+      {/* Background aura */}
+      <circle
+        cx="50"
+        cy="50"
+        r={lerp(15, 45, t)}
+        fill={`url(#blob-glow-${uid})`}
+        className="transition-all duration-1000"
+      />
+
+      {/* Main blob */}
+      <g filter={stage < 10 ? `url(#blob-goo-${uid})` : undefined}>
+        <path
+          d={path}
+          fill={`url(#blob-grad-${uid})`}
+          stroke={stage >= 8 ? '#2D7FF9' : 'none'}
+          strokeWidth={lerp(0, 0.8, (stage - 8) / 8)}
+          opacity={lerp(0.4, 1, t)}
+          className={cn('transition-all duration-1000', animate && stage < 10 && 'lyra-blob-morph')}
+        />
+
+        {/* Inner highlight */}
+        {stage >= 3 && (
+          <path
+            d={path}
+            fill="white"
+            opacity={lerp(0.02, 0.08, t)}
+            transform="translate(2, -2) scale(0.9)"
+            style={{ transformOrigin: '50px 50px' }}
+            className="transition-all duration-1000"
+          />
+        )}
+      </g>
+
+      {/* Eyes emerge */}
+      {stage >= 5 && (
+        <>
+          <circle
+            cx={lerp(44, 44, t)}
+            cy={lerp(48, 30, t)}
+            r={lerp(1, 2.5, (stage - 5) / 11)}
+            fill="white"
+            opacity={lerp(0.3, 1, (stage - 5) / 11)}
+            className="transition-all duration-1000"
+          />
+          <circle
+            cx={lerp(56, 56, t)}
+            cy={lerp(48, 30, t)}
+            r={lerp(1, 2.5, (stage - 5) / 11)}
+            fill="white"
+            opacity={lerp(0.3, 1, (stage - 5) / 11)}
+            className="transition-all duration-1000"
+          />
+          {/* Pupils */}
+          {stage >= 7 && (
+            <>
+              <circle
+                cx={lerp(44.5, 44.5, t)}
+                cy={lerp(48, 30, t)}
+                r={lerp(0.3, 1, (stage - 7) / 9)}
+                fill="#2D7FF9"
+                opacity={lerp(0.3, 1, (stage - 7) / 9)}
+                className="transition-all duration-1000"
+              />
+              <circle
+                cx={lerp(56.5, 56.5, t)}
+                cy={lerp(48, 30, t)}
+                r={lerp(0.3, 1, (stage - 7) / 9)}
+                fill="#2D7FF9"
+                opacity={lerp(0.3, 1, (stage - 7) / 9)}
+                className="transition-all duration-1000"
+              />
+            </>
+          )}
+        </>
+      )}
+
+      {/* Mouth */}
+      {stage >= 8 && (
+        <path
+          d={`M ${lerp(46, 44, t)} ${lerp(54, 36, t)} Q 50 ${lerp(56, 38, t)} ${lerp(54, 56, t)} ${lerp(54, 36, t)}`}
+          fill="none"
+          stroke="white"
+          strokeWidth="0.5"
+          opacity={lerp(0.2, 0.6, (stage - 8) / 8)}
+          className="transition-all duration-1000"
+        />
+      )}
+
+      {/* Flowing tendrils / hair */}
+      {stage >= 10 && (
+        <>
+          <path
+            d={`M 38 ${lerp(40, 25, (stage - 10) / 6)} Q 30 ${lerp(45, 35, (stage - 10) / 6)} 28 ${lerp(55, 50, (stage - 10) / 6)}`}
+            fill="none"
+            stroke="#8B5CF6"
+            strokeWidth={lerp(0.5, 2, (stage - 10) / 6)}
+            strokeLinecap="round"
+            opacity={lerp(0.3, 0.7, (stage - 10) / 6)}
+            className={cn('transition-all duration-1000', animate && 'lyra-tendril-1')}
+          />
+          <path
+            d={`M 62 ${lerp(40, 25, (stage - 10) / 6)} Q 70 ${lerp(45, 35, (stage - 10) / 6)} 72 ${lerp(55, 50, (stage - 10) / 6)}`}
+            fill="none"
+            stroke="#8B5CF6"
+            strokeWidth={lerp(0.5, 2, (stage - 10) / 6)}
+            strokeLinecap="round"
+            opacity={lerp(0.3, 0.7, (stage - 10) / 6)}
+            className={cn('transition-all duration-1000', animate && 'lyra-tendril-2')}
+          />
+        </>
+      )}
+
+      {/* Crown / identity glow */}
+      {stage >= 12 && (
+        <circle
+          cx="50"
+          cy={lerp(38, 18, (stage - 12) / 4)}
+          r={lerp(1, 3, (stage - 12) / 4)}
+          fill="#ffd700"
+          opacity={lerp(0.3, 0.8, (stage - 12) / 4)}
+          filter={`url(#blob-blur-${uid})`}
+          className="transition-all duration-1000"
+        />
+      )}
+
+      {/* Particles detaching */}
+      {stage >= 11 && (
+        <>
+          {PARTICLE_POSITIONS.slice(0, Math.min(stage - 10, 8)).map((p) => (
+            <circle
+              key={`${p.x}-${p.y}`}
+              cx={p.x}
+              cy={p.y}
+              r="1"
+              fill={p.x > 50 ? '#8B5CF6' : '#2D7FF9'}
+              opacity="0.4"
+              className={cn(animate && 'lyra-satellite')}
+            />
+          ))}
+        </>
+      )}
+    </svg>
+  )
+}
+
+const PARTICLE_POSITIONS = [
+  { x: 20, y: 30 },
+  { x: 80, y: 35 },
+  { x: 15, y: 60 },
+  { x: 85, y: 55 },
+  { x: 25, y: 80 },
+  { x: 75, y: 85 },
+  { x: 10, y: 45 },
+  { x: 90, y: 50 },
+]
+
+// Keyframe paths: amorphous blob → head+body → full humanoid
+// Each stage interpolates between these keyframes
+const BLOB_PATHS: Record<number, string> = {
+  // 0: tiny dot
+  0: 'M 48 48 Q 50 46 52 48 Q 54 50 52 52 Q 50 54 48 52 Q 46 50 48 48 Z',
+  // 1: small circle
+  1: 'M 44 44 Q 50 38 56 44 Q 62 50 56 56 Q 50 62 44 56 Q 38 50 44 44 Z',
+  // 2: glitchy/jittery
+  2: 'M 42 40 Q 52 36 58 42 Q 64 52 56 58 Q 48 62 42 56 Q 36 48 42 40 Z',
+  // 3: stable blob
+  3: 'M 38 42 Q 50 32 62 42 Q 68 52 62 60 Q 50 68 38 60 Q 32 52 38 42 Z',
+  // 4: larger, head-like
+  4: 'M 36 38 Q 50 28 64 38 Q 72 50 64 62 Q 50 72 36 62 Q 28 50 36 38 Z',
+  // 5: head + body bump
+  5: 'M 38 30 Q 50 20 62 30 Q 68 42 64 55 Q 60 70 50 72 Q 40 70 36 55 Q 32 42 38 30 Z',
+  // 6: clearer head separation
+  6: 'M 40 28 Q 50 18 60 28 Q 66 38 62 48 Q 66 58 62 70 Q 50 78 38 70 Q 34 58 38 48 Q 34 38 40 28 Z',
+  // 7-8: arms forming
+  7: 'M 42 25 Q 50 16 58 25 Q 64 34 60 44 Q 70 48 68 55 Q 64 60 60 58 Q 62 70 50 78 Q 38 70 40 58 Q 36 60 32 55 Q 30 48 40 44 Q 36 34 42 25 Z',
+  // 9-10: clear humanoid
+  9: 'M 43 22 Q 50 14 57 22 Q 62 30 58 40 Q 70 44 70 52 Q 68 56 62 54 Q 60 68 56 80 Q 54 85 52 80 L 50 70 L 48 80 Q 46 85 44 80 Q 40 68 38 54 Q 32 56 30 52 Q 30 44 42 40 Q 38 30 43 22 Z',
+  // 13-16: refined humanoid with flowing form
+  13: 'M 44 18 Q 50 10 56 18 Q 60 26 58 36 Q 68 40 70 48 Q 70 54 64 52 L 62 56 Q 66 70 64 85 Q 60 90 56 85 L 52 70 L 50 68 L 48 70 L 44 85 Q 40 90 36 85 Q 34 70 38 56 L 36 52 Q 30 54 30 48 Q 30 40 42 36 Q 40 26 44 18 Z',
+}
+
+function interpolatePath(stage: number): string {
+  // Find the two nearest keyframes and interpolate
+  const keys = Object.keys(BLOB_PATHS)
+    .map(Number)
+    .sort((a, b) => a - b)
+
+  if (stage <= keys[0]!) return BLOB_PATHS[keys[0]!]!
+
+  const lastKey = keys[keys.length - 1]!
+  if (stage >= lastKey) return BLOB_PATHS[lastKey]!
+
+  // Find surrounding keyframes
+  let lower = keys[0]!
+  let upper = lastKey
+  for (const k of keys) {
+    if (k <= stage) lower = k
+    if (k > stage) {
+      upper = k
+      break
+    }
+  }
+
+  if (lower === upper) return BLOB_PATHS[lower]!
+
+  // For stages between keyframes, use the lower keyframe
+  // (true path interpolation would need path parsing — keep it simple)
+  return BLOB_PATHS[lower]!
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}

--- a/apps/web/src/components/presentation/lyra-story/variants/PokemonVariant.tsx
+++ b/apps/web/src/components/presentation/lyra-story/variants/PokemonVariant.tsx
@@ -1,0 +1,744 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: SVG-heavy visual component with 5 evolution phases
+import { cn, useReducedMotion } from '@repo/ui'
+import { useId } from 'react'
+
+type PokemonVariantProps = {
+  stage: number
+  size: number
+  className?: string
+}
+
+const BLUE = '#2D7FF9'
+const PURPLE = '#8B5CF6'
+const LIGHT_BLUE = '#7BB8FF'
+const DARK_BLUE = '#1a3a6e'
+const WHITE = '#ffffff'
+const GOLD = '#ffd700'
+
+// Evolution phases:
+// 0-1:   Egg
+// 2:     Cracking egg
+// 3-5:   Baby — small round creature, big eyes, stubby limbs
+// 6-9:   Teen — ears grow, tail appears, more defined body
+// 10-13: Adult — crest/mane, wings/fins, powerful stance
+// 14-16: Mega — glowing aura, crystal patterns, ultimate form
+
+export function PokemonVariant({ stage, size, className }: PokemonVariantProps) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const animate = !reducedMotion
+  const t = stage / 16
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={cn('transition-all duration-1000', className)}
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id={`pk-glow-${uid}`} cx="50%" cy="40%" r="50%">
+          <stop offset="0%" stopColor={BLUE} stopOpacity={lerp(0, 0.3, t)} />
+          <stop offset="100%" stopColor="transparent" />
+        </radialGradient>
+        <filter id={`pk-blur-${uid}`} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="2" />
+        </filter>
+        <filter id={`pk-soft-${uid}`} x="-100%" y="-100%" width="300%" height="300%">
+          <feGaussianBlur stdDeviation="4" />
+        </filter>
+      </defs>
+
+      {/* Background aura (mega stage) */}
+      {stage >= 14 && (
+        <circle
+          cx="50"
+          cy="50"
+          r={lerp(30, 45, (stage - 14) / 2)}
+          fill={`url(#pk-glow-${uid})`}
+          opacity={lerp(0.3, 0.6, (stage - 14) / 2)}
+          filter={`url(#pk-soft-${uid})`}
+          className={cn(animate && 'lyra-core-pulse')}
+        />
+      )}
+
+      {stage <= 2 ? (
+        <Egg stage={stage} uid={uid} animate={animate} />
+      ) : stage <= 5 ? (
+        <Baby stage={stage} uid={uid} animate={animate} />
+      ) : stage <= 9 ? (
+        <Teen stage={stage} uid={uid} animate={animate} />
+      ) : stage <= 13 ? (
+        <Adult stage={stage} uid={uid} animate={animate} />
+      ) : (
+        <Mega stage={stage} uid={uid} animate={animate} />
+      )}
+    </svg>
+  )
+}
+
+// ─── Egg ─────────────────────────────────────────────────────────────────────
+
+function Egg({ stage, animate }: { stage: number; uid: string; animate: boolean }) {
+  const wobble = stage === 2 && animate
+
+  return (
+    <g className={cn(wobble && 'lyra-tama-wobble')}>
+      {/* Egg body */}
+      <ellipse
+        cx="50"
+        cy="55"
+        rx={stage === 0 ? 8 : 14}
+        ry={stage === 0 ? 10 : 18}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.5"
+        className="transition-all duration-1000"
+      />
+      {/* Egg pattern — zigzag line */}
+      {stage >= 1 && (
+        <path
+          d="M 38 52 L 42 48 L 46 52 L 50 48 L 54 52 L 58 48 L 62 52"
+          fill="none"
+          stroke={PURPLE}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          opacity={0.6}
+          className="transition-all duration-1000"
+        />
+      )}
+      {/* Star mark */}
+      {stage >= 1 && (
+        <polygon
+          points="50,40 51.5,44 56,44 52.5,46.5 54,50 50,48 46,50 47.5,46.5 44,44 48.5,44"
+          fill={GOLD}
+          opacity={0.7}
+          className="transition-all duration-500"
+        />
+      )}
+      {/* Crack lines */}
+      {stage === 2 && (
+        <>
+          <path
+            d="M 44 45 L 47 50 L 44 55"
+            fill="none"
+            stroke={DARK_BLUE}
+            strokeWidth="1"
+            opacity="0.6"
+          />
+          <path
+            d="M 56 43 L 53 48 L 57 52"
+            fill="none"
+            stroke={DARK_BLUE}
+            strokeWidth="1"
+            opacity="0.6"
+          />
+        </>
+      )}
+    </g>
+  )
+}
+
+// ─── Baby (stages 3-5) ──────────────────────────────────────────────────────
+
+function Baby({ stage, animate }: { stage: number; uid: string; animate: boolean }) {
+  const bounce = animate
+  const eyeSize = lerp(3, 4, (stage - 3) / 2)
+
+  return (
+    <g className={cn(bounce && 'lyra-tama-bounce')}>
+      {/* Body — round blob */}
+      <ellipse
+        cx="50"
+        cy="58"
+        rx={lerp(14, 16, (stage - 3) / 2)}
+        ry={lerp(12, 14, (stage - 3) / 2)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+        className="transition-all duration-1000"
+      />
+
+      {/* Head — slightly overlapping top of body */}
+      <circle
+        cx="50"
+        cy="42"
+        r={lerp(12, 14, (stage - 3) / 2)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+        className="transition-all duration-1000"
+      />
+
+      {/* Eyes — big and cute */}
+      <circle cx="44" cy="40" r={eyeSize} fill={WHITE} />
+      <circle cx="56" cy="40" r={eyeSize} fill={WHITE} />
+      <circle cx={lerp(44.5, 45, (stage - 3) / 2)} cy="40" r={eyeSize * 0.55} fill={DARK_BLUE} />
+      <circle cx={lerp(56.5, 57, (stage - 3) / 2)} cy="40" r={eyeSize * 0.55} fill={DARK_BLUE} />
+      {/* Eye shine */}
+      <circle cx="43" cy="39" r="1" fill={WHITE} opacity="0.9" />
+      <circle cx="55" cy="39" r="1" fill={WHITE} opacity="0.9" />
+
+      {/* Mouth — small happy curve */}
+      <path
+        d="M 47 45 Q 50 48 53 45"
+        fill="none"
+        stroke={DARK_BLUE}
+        strokeWidth="0.8"
+        strokeLinecap="round"
+      />
+
+      {/* Stubby arms */}
+      {stage >= 4 && (
+        <>
+          <ellipse
+            cx="35"
+            cy="54"
+            rx="4"
+            ry="3"
+            fill={LIGHT_BLUE}
+            stroke={BLUE}
+            strokeWidth="0.8"
+          />
+          <ellipse
+            cx="65"
+            cy="54"
+            rx="4"
+            ry="3"
+            fill={LIGHT_BLUE}
+            stroke={BLUE}
+            strokeWidth="0.8"
+          />
+        </>
+      )}
+
+      {/* Small feet */}
+      {stage >= 4 && (
+        <>
+          <ellipse cx="44" cy="70" rx="4" ry="2.5" fill={BLUE} opacity="0.7" />
+          <ellipse cx="56" cy="70" rx="4" ry="2.5" fill={BLUE} opacity="0.7" />
+        </>
+      )}
+
+      {/* Tiny ear bumps */}
+      {stage >= 5 && (
+        <>
+          <ellipse
+            cx="40"
+            cy="30"
+            rx="3"
+            ry="5"
+            fill={LIGHT_BLUE}
+            stroke={BLUE}
+            strokeWidth="0.8"
+            transform="rotate(-15, 40, 30)"
+          />
+          <ellipse
+            cx="60"
+            cy="30"
+            rx="3"
+            ry="5"
+            fill={LIGHT_BLUE}
+            stroke={BLUE}
+            strokeWidth="0.8"
+            transform="rotate(15, 60, 30)"
+          />
+        </>
+      )}
+
+      {/* Star mark on forehead */}
+      <polygon
+        points="50,33 51,35 53,35 51.5,36.5 52,38.5 50,37.5 48,38.5 48.5,36.5 47,35 49,35"
+        fill={GOLD}
+        opacity="0.7"
+      />
+    </g>
+  )
+}
+
+// ─── Teen (stages 6-9) ──────────────────────────────────────────────────────
+
+function Teen({ stage, uid, animate }: { stage: number; uid: string; animate: boolean }) {
+  const t = (stage - 6) / 3
+
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Tail */}
+      <path
+        d={`M 62 62 Q ${lerp(70, 75, t)} ${lerp(55, 50, t)} ${lerp(72, 80, t)} ${lerp(45, 38, t)}`}
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth={lerp(2, 3, t)}
+        strokeLinecap="round"
+        opacity={lerp(0.5, 0.9, t)}
+        className={cn('transition-all duration-1000', animate && 'lyra-tendril-1')}
+      />
+      {/* Tail tip glow */}
+      {stage >= 8 && (
+        <circle
+          cx={lerp(72, 80, t)}
+          cy={lerp(45, 38, t)}
+          r="3"
+          fill={BLUE}
+          opacity="0.5"
+          filter={`url(#pk-blur-${uid})`}
+        />
+      )}
+
+      {/* Body */}
+      <ellipse
+        cx="50"
+        cy="62"
+        rx={lerp(14, 16, t)}
+        ry={lerp(11, 13, t)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+        className="transition-all duration-1000"
+      />
+
+      {/* Head */}
+      <circle
+        cx="50"
+        cy="40"
+        r={lerp(13, 15, t)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+        className="transition-all duration-1000"
+      />
+
+      {/* Ears — growing taller */}
+      <path
+        d={`M 39 32 Q ${lerp(36, 33, t)} ${lerp(22, 14, t)} ${lerp(42, 40, t)} ${lerp(28, 24, t)}`}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1"
+        className="transition-all duration-1000"
+      />
+      <path
+        d={`M 61 32 Q ${lerp(64, 67, t)} ${lerp(22, 14, t)} ${lerp(58, 60, t)} ${lerp(28, 24, t)}`}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1"
+        className="transition-all duration-1000"
+      />
+      {/* Inner ear color */}
+      {stage >= 7 && (
+        <>
+          <path d={`M 40 31 Q 35 20 41 26`} fill={PURPLE} opacity="0.3" />
+          <path d={`M 60 31 Q 65 20 59 26`} fill={PURPLE} opacity="0.3" />
+        </>
+      )}
+
+      {/* Eyes */}
+      <circle cx="43" cy="38" r={lerp(3.5, 4, t)} fill={WHITE} />
+      <circle cx="57" cy="38" r={lerp(3.5, 4, t)} fill={WHITE} />
+      <circle cx="44" cy="38" r={lerp(2, 2.5, t)} fill={BLUE} />
+      <circle cx="58" cy="38" r={lerp(2, 2.5, t)} fill={BLUE} />
+      <circle cx="43" cy="37" r="1" fill={WHITE} opacity="0.9" />
+      <circle cx="57" cy="37" r="1" fill={WHITE} opacity="0.9" />
+
+      {/* Mouth */}
+      <path
+        d={`M 46 44 Q 50 ${lerp(47, 48, t)} 54 44`}
+        fill="none"
+        stroke={DARK_BLUE}
+        strokeWidth="0.8"
+        strokeLinecap="round"
+      />
+
+      {/* Arms */}
+      <ellipse
+        cx="34"
+        cy="58"
+        rx={lerp(4, 5, t)}
+        ry="3.5"
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="0.8"
+      />
+      <ellipse
+        cx="66"
+        cy="58"
+        rx={lerp(4, 5, t)}
+        ry="3.5"
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="0.8"
+      />
+
+      {/* Feet */}
+      <ellipse cx="43" cy="73" rx="5" ry="3" fill={BLUE} opacity="0.7" />
+      <ellipse cx="57" cy="73" rx="5" ry="3" fill={BLUE} opacity="0.7" />
+
+      {/* Chest marking */}
+      {stage >= 8 && (
+        <ellipse
+          cx="50"
+          cy="60"
+          rx="6"
+          ry="5"
+          fill={WHITE}
+          opacity="0.3"
+          className="transition-all duration-1000"
+        />
+      )}
+
+      {/* Forehead star */}
+      <polygon
+        points="50,30 51.2,33 54,33 52,34.8 52.8,37.5 50,36 47.2,37.5 48,34.8 46,33 48.8,33"
+        fill={GOLD}
+        opacity={lerp(0.6, 0.9, t)}
+      />
+    </g>
+  )
+}
+
+// ─── Adult (stages 10-13) ───────────────────────────────────────────────────
+
+function Adult({ stage, uid, animate }: { stage: number; uid: string; animate: boolean }) {
+  const t = (stage - 10) / 3
+
+  return (
+    <g>
+      {/* Aura circle */}
+      <circle
+        cx="50"
+        cy="50"
+        r={lerp(35, 42, t)}
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth="0.5"
+        opacity={lerp(0.1, 0.3, t)}
+        filter={`url(#pk-soft-${uid})`}
+        className="transition-all duration-1000"
+      />
+
+      {/* Tail — longer, flowing */}
+      <path
+        d={`M 64 58 Q 78 48 ${lerp(80, 85, t)} ${lerp(35, 28, t)} Q ${lerp(82, 88, t)} ${lerp(28, 20, t)} ${lerp(78, 82, t)} ${lerp(25, 18, t)}`}
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth={lerp(2.5, 3.5, t)}
+        strokeLinecap="round"
+        className={cn('transition-all duration-1000', animate && 'lyra-tendril-1')}
+      />
+      {/* Tail tip star */}
+      {stage >= 12 && (
+        <circle
+          cx={lerp(78, 82, t)}
+          cy={lerp(25, 18, t)}
+          r="3"
+          fill={GOLD}
+          opacity="0.7"
+          filter={`url(#pk-blur-${uid})`}
+          className={cn(animate && 'lyra-star-pulse')}
+        />
+      )}
+
+      {/* Wings/fins */}
+      {stage >= 11 && (
+        <>
+          <path
+            d={`M 38 50 Q ${lerp(25, 18, (stage - 11) / 2)} ${lerp(42, 35, (stage - 11) / 2)} ${lerp(22, 15, (stage - 11) / 2)} ${lerp(50, 45, (stage - 11) / 2)} Q ${lerp(28, 22, (stage - 11) / 2)} ${lerp(55, 52, (stage - 11) / 2)} 38 55`}
+            fill={PURPLE}
+            opacity={lerp(0.2, 0.5, (stage - 11) / 2)}
+            stroke={PURPLE}
+            strokeWidth="0.5"
+            className="transition-all duration-1000"
+          />
+          <path
+            d={`M 62 50 Q ${lerp(75, 82, (stage - 11) / 2)} ${lerp(42, 35, (stage - 11) / 2)} ${lerp(78, 85, (stage - 11) / 2)} ${lerp(50, 45, (stage - 11) / 2)} Q ${lerp(72, 78, (stage - 11) / 2)} ${lerp(55, 52, (stage - 11) / 2)} 62 55`}
+            fill={PURPLE}
+            opacity={lerp(0.2, 0.5, (stage - 11) / 2)}
+            stroke={PURPLE}
+            strokeWidth="0.5"
+            className="transition-all duration-1000"
+          />
+        </>
+      )}
+
+      {/* Body */}
+      <ellipse
+        cx="50"
+        cy="60"
+        rx={lerp(15, 16, t)}
+        ry={lerp(14, 15, t)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+      />
+      {/* Chest marking */}
+      <ellipse cx="50" cy="58" rx="7" ry="6" fill={WHITE} opacity="0.25" />
+
+      {/* Head */}
+      <circle
+        cx="50"
+        cy="36"
+        r={lerp(14, 15, t)}
+        fill={LIGHT_BLUE}
+        stroke={BLUE}
+        strokeWidth="1.2"
+      />
+
+      {/* Ears — tall and pointed */}
+      <path d={`M 38 28 Q 30 10 42 22`} fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+      <path d={`M 62 28 Q 70 10 58 22`} fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+      <path d="M 39 27 Q 33 16 41 23" fill={PURPLE} opacity="0.3" />
+      <path d="M 61 27 Q 67 16 59 23" fill={PURPLE} opacity="0.3" />
+
+      {/* Crest/mane */}
+      {stage >= 11 && (
+        <>
+          <path
+            d={`M 44 24 Q 50 ${lerp(18, 12, (stage - 11) / 2)} 56 24`}
+            fill={BLUE}
+            opacity={lerp(0.4, 0.8, (stage - 11) / 2)}
+            className="transition-all duration-1000"
+          />
+          <path
+            d={`M 46 22 Q 50 ${lerp(16, 8, (stage - 11) / 2)} 54 22`}
+            fill={PURPLE}
+            opacity={lerp(0.3, 0.6, (stage - 11) / 2)}
+            className="transition-all duration-1000"
+          />
+        </>
+      )}
+
+      {/* Eyes — sharper, more determined */}
+      <circle cx="43" cy="34" r="4.5" fill={WHITE} />
+      <circle cx="57" cy="34" r="4.5" fill={WHITE} />
+      <circle cx="44" cy="34" r="2.8" fill={BLUE} />
+      <circle cx="58" cy="34" r="2.8" fill={BLUE} />
+      <circle cx="43" cy="33" r="1.2" fill={WHITE} opacity="0.9" />
+      <circle cx="57" cy="33" r="1.2" fill={WHITE} opacity="0.9" />
+
+      {/* Confident mouth */}
+      <path
+        d="M 46 41 Q 50 44 54 41"
+        fill="none"
+        stroke={DARK_BLUE}
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+
+      {/* Arms — stronger */}
+      <ellipse cx="33" cy="56" rx="5" ry="4" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="0.8" />
+      <ellipse cx="67" cy="56" rx="5" ry="4" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="0.8" />
+
+      {/* Feet */}
+      <ellipse cx="42" cy="73" rx="5.5" ry="3" fill={BLUE} opacity="0.7" />
+      <ellipse cx="58" cy="73" rx="5.5" ry="3" fill={BLUE} opacity="0.7" />
+
+      {/* Forehead gem */}
+      <polygon
+        points="50,26 52,29 55,29 52.5,31 53.5,34 50,32.5 46.5,34 47.5,31 45,29 48,29"
+        fill={GOLD}
+        opacity="0.9"
+      />
+
+      {/* Sparkle particles */}
+      {stage >= 12 &&
+        SPARKLE_POSITIONS.slice(0, stage - 11).map((p) => (
+          <circle
+            key={`${p.x}-${p.y}`}
+            cx={p.x}
+            cy={p.y}
+            r="1"
+            fill={p.x > 50 ? PURPLE : BLUE}
+            opacity="0.5"
+            className={cn(animate && 'lyra-satellite')}
+          />
+        ))}
+    </g>
+  )
+}
+
+// ─── Mega (stages 14-16) ────────────────────────────────────────────────────
+
+function Mega({ stage, uid, animate }: { stage: number; uid: string; animate: boolean }) {
+  const t = (stage - 14) / 2
+
+  return (
+    <g>
+      {/* Outer aura rings */}
+      <circle
+        cx="50"
+        cy="50"
+        r={lerp(40, 46, t)}
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth={lerp(0.5, 1, t)}
+        opacity={lerp(0.15, 0.35, t)}
+        className={cn('transition-all duration-1000', animate && 'lyra-ring1')}
+        style={{ transformOrigin: '50px 50px' }}
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r={lerp(36, 42, t)}
+        fill="none"
+        stroke={BLUE}
+        strokeWidth="0.5"
+        opacity={lerp(0.1, 0.25, t)}
+        className={cn('transition-all duration-1000', animate && 'lyra-ring2')}
+        style={{ transformOrigin: '50px 50px' }}
+      />
+
+      {/* Crystal wing patterns */}
+      <path
+        d={`M 35 48 L ${lerp(15, 8, t)} ${lerp(32, 25, t)} L ${lerp(20, 14, t)} ${lerp(45, 40, t)} L 35 53 Z`}
+        fill={PURPLE}
+        opacity={lerp(0.3, 0.6, t)}
+        stroke={LIGHT_BLUE}
+        strokeWidth="0.5"
+        className="transition-all duration-1000"
+      />
+      <path
+        d={`M 65 48 L ${lerp(85, 92, t)} ${lerp(32, 25, t)} L ${lerp(80, 86, t)} ${lerp(45, 40, t)} L 65 53 Z`}
+        fill={PURPLE}
+        opacity={lerp(0.3, 0.6, t)}
+        stroke={LIGHT_BLUE}
+        strokeWidth="0.5"
+        className="transition-all duration-1000"
+      />
+      {/* Lower wing segments */}
+      <path
+        d={`M 36 54 L ${lerp(18, 12, t)} ${lerp(55, 52, t)} L ${lerp(22, 16, t)} ${lerp(62, 60, t)} L 38 58 Z`}
+        fill={BLUE}
+        opacity={lerp(0.2, 0.4, t)}
+        className="transition-all duration-1000"
+      />
+      <path
+        d={`M 64 54 L ${lerp(82, 88, t)} ${lerp(55, 52, t)} L ${lerp(78, 84, t)} ${lerp(62, 60, t)} L 62 58 Z`}
+        fill={BLUE}
+        opacity={lerp(0.2, 0.4, t)}
+        className="transition-all duration-1000"
+      />
+
+      {/* Flowing tail */}
+      <path
+        d={`M 62 60 Q 80 45 85 25 Q 88 18 84 15`}
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        className={cn(animate && 'lyra-tendril-1')}
+      />
+      <circle
+        cx="84"
+        cy="15"
+        r="4"
+        fill={GOLD}
+        opacity="0.8"
+        filter={`url(#pk-blur-${uid})`}
+        className={cn(animate && 'lyra-star-pulse')}
+      />
+
+      {/* Body */}
+      <ellipse cx="50" cy="60" rx="16" ry="15" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1.5" />
+      {/* Chest crystal pattern */}
+      <path
+        d="M 50 50 L 44 58 L 50 66 L 56 58 Z"
+        fill={WHITE}
+        opacity="0.2"
+        stroke={BLUE}
+        strokeWidth="0.5"
+      />
+
+      {/* Head */}
+      <circle cx="50" cy="36" r="15" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1.5" />
+
+      {/* Crown crest */}
+      <path
+        d={`M 42 24 L 38 ${lerp(12, 6, t)} L 44 18 L 50 ${lerp(10, 4, t)} L 56 18 L 62 ${lerp(12, 6, t)} L 58 24`}
+        fill={GOLD}
+        opacity={lerp(0.5, 0.9, t)}
+        stroke={GOLD}
+        strokeWidth="0.5"
+        className="transition-all duration-1000"
+      />
+
+      {/* Ears */}
+      <path d="M 37 28 Q 28 8 42 22" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+      <path d="M 63 28 Q 72 8 58 22" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+      <path d="M 38 27 Q 31 14 41 23" fill={PURPLE} opacity="0.4" />
+      <path d="M 62 27 Q 69 14 59 23" fill={PURPLE} opacity="0.4" />
+
+      {/* Eyes — glowing, powerful */}
+      <circle cx="43" cy="34" r="5" fill={WHITE} />
+      <circle cx="57" cy="34" r="5" fill={WHITE} />
+      <circle cx="44" cy="34" r="3" fill={BLUE} />
+      <circle cx="58" cy="34" r="3" fill={BLUE} />
+      {/* Eye glow */}
+      <circle cx="44" cy="34" r="5" fill={BLUE} opacity="0.15" filter={`url(#pk-blur-${uid})`} />
+      <circle cx="58" cy="34" r="5" fill={BLUE} opacity="0.15" filter={`url(#pk-blur-${uid})`} />
+      <circle cx="43" cy="33" r="1.3" fill={WHITE} opacity="0.95" />
+      <circle cx="57" cy="33" r="1.3" fill={WHITE} opacity="0.95" />
+
+      {/* Determined smile */}
+      <path
+        d="M 45 41 Q 50 45 55 41"
+        fill="none"
+        stroke={DARK_BLUE}
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+
+      {/* Forehead mega gem */}
+      <polygon
+        points="50,25 52.5,28.5 56,29 53,31.5 54,35 50,33 46,35 47,31.5 44,29 47.5,28.5"
+        fill={GOLD}
+      />
+      <circle cx="50" cy="30" r="2" fill={WHITE} opacity="0.4" filter={`url(#pk-blur-${uid})`} />
+
+      {/* Arms */}
+      <ellipse cx="32" cy="56" rx="5.5" ry="4" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+      <ellipse cx="68" cy="56" rx="5.5" ry="4" fill={LIGHT_BLUE} stroke={BLUE} strokeWidth="1" />
+
+      {/* Feet */}
+      <ellipse cx="42" cy="73" rx="6" ry="3" fill={BLUE} opacity="0.8" />
+      <ellipse cx="58" cy="73" rx="6" ry="3" fill={BLUE} opacity="0.8" />
+
+      {/* Floating sparkles */}
+      {MEGA_SPARKLES.map((p) => (
+        <circle
+          key={`${p.x}-${p.y}`}
+          cx={p.x}
+          cy={p.y}
+          r={p.r}
+          fill={p.color}
+          opacity={lerp(0.3, 0.7, t)}
+          className={cn(animate && 'lyra-satellite')}
+        />
+      ))}
+    </g>
+  )
+}
+
+// prettier-ignore
+const SPARKLE_POSITIONS = [
+  { x: 20, y: 25 },
+  { x: 80, y: 30 },
+  { x: 15, y: 55 },
+  { x: 85, y: 60 },
+  { x: 25, y: 78 },
+  { x: 75, y: 82 },
+]
+// prettier-ignore
+const MEGA_SPARKLES = [
+  { x: 12, y: 20, r: 1.5, color: GOLD },
+  { x: 88, y: 22, r: 1, color: PURPLE },
+  { x: 8, y: 50, r: 1, color: BLUE },
+  { x: 92, y: 48, r: 1.5, color: GOLD },
+  { x: 15, y: 75, r: 1, color: PURPLE },
+  { x: 85, y: 78, r: 1, color: BLUE },
+  { x: 25, y: 12, r: 1, color: BLUE },
+  { x: 75, y: 10, r: 1.5, color: GOLD },
+]
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}

--- a/apps/web/src/components/presentation/lyra-story/variants/RpgCanvasVariant.tsx
+++ b/apps/web/src/components/presentation/lyra-story/variants/RpgCanvasVariant.tsx
@@ -1,0 +1,192 @@
+import { cn, useReducedMotion } from '@repo/ui'
+import { useCallback, useEffect, useRef } from 'react'
+
+type RpgCanvasVariantProps = {
+  stage: number
+  size: number
+  className?: string
+}
+
+// Colors
+const SKIN = '#e0c8a8'
+const HAIR = '#2D7FF9'
+const DARK = '#1a1a3e'
+const BLUE = '#2D7FF9'
+const PURPLE = '#8B5CF6'
+const GOLD = '#ffd700'
+const SILVER = '#c0c0c0'
+
+// 16x16 grid sprite frames — each is an array of [x, y, color] tuples
+type Pixel = [number, number, string]
+
+function getCharacterPixels(stage: number): Pixel[] {
+  const pixels: Pixel[] = []
+
+  if (stage === 0) {
+    pixels.push([8, 9, BLUE])
+    return pixels
+  }
+
+  if (stage === 1) {
+    pixels.push([8, 8, BLUE], [7, 9, PURPLE], [9, 9, PURPLE])
+    return pixels
+  }
+
+  if (stage === 2) {
+    pixels.push(
+      [7, 7, BLUE],
+      [8, 7, BLUE],
+      [9, 7, BLUE],
+      [7, 8, BLUE],
+      [8, 8, '#ff4444'],
+      [9, 8, BLUE],
+      [7, 9, BLUE],
+      [8, 9, BLUE],
+      [9, 9, BLUE]
+    )
+    return pixels
+  }
+
+  // Base character (stage 3+)
+  // Head
+  for (let x = 7; x <= 10; x++) for (let y = 3; y <= 6; y++) pixels.push([x, y, SKIN])
+  // Eyes
+  pixels.push([8, 4, DARK], [10, 4, DARK])
+  // Body
+  for (let x = 7; x <= 10; x++) for (let y = 7; y <= 10; y++) pixels.push([x, y, BLUE])
+  // Legs
+  for (let y = 11; y <= 13; y++) {
+    pixels.push([7, y, DARK], [8, y, DARK], [9, y, DARK], [10, y, DARK])
+  }
+
+  if (stage >= 4) pixels.push([8, 5, '#c89878'], [9, 5, '#c89878'])
+  if (stage >= 5) {
+    pixels.push([5, 7, SKIN], [6, 7, SKIN], [11, 7, SKIN], [12, 7, SKIN])
+    pixels.push([5, 8, SKIN], [5, 9, SKIN], [12, 8, SKIN], [12, 9, SKIN])
+  }
+  if (stage >= 6) {
+    pixels.push([8, 8, '#1e5fc2'], [9, 8, '#1e5fc2'], [8, 9, '#1e5fc2'], [9, 9, '#1e5fc2'])
+  }
+  if (stage >= 7) {
+    for (let y = 4; y <= 11; y++) pixels.push([6, y, PURPLE])
+    for (let y = 4; y <= 11; y++) pixels.push([11, y, PURPLE])
+    pixels.push([5, 11, PURPLE], [6, 12, PURPLE], [11, 11, PURPLE], [12, 12, PURPLE])
+  }
+  if (stage >= 8) {
+    pixels.push([7, 2, HAIR], [8, 2, HAIR], [9, 2, HAIR], [10, 2, HAIR])
+    pixels.push([6, 3, HAIR], [6, 4, HAIR], [11, 3, HAIR], [11, 4, HAIR])
+  }
+  if (stage >= 9) {
+    pixels.push([7, 1, GOLD], [9, 1, GOLD], [8, 0, GOLD], [9, 0, GOLD], [10, 1, GOLD])
+  }
+  if (stage >= 10) {
+    pixels.push([8, 4, BLUE], [10, 4, BLUE])
+  }
+  if (stage >= 11) {
+    pixels.push([2, 5, BLUE], [15, 5, PURPLE], [2, 12, PURPLE])
+  }
+  if (stage >= 12) {
+    pixels.push(
+      [13, 5, SILVER],
+      [13, 6, SILVER],
+      [13, 7, '#a0a0a0'],
+      [13, 8, '#a0a0a0'],
+      [13, 9, '#a0a0a0'],
+      [12, 7, GOLD],
+      [14, 7, GOLD]
+    )
+  }
+  if (stage >= 13) {
+    pixels.push(
+      [3, 7, BLUE],
+      [4, 7, BLUE],
+      [3, 8, BLUE],
+      [4, 8, '#1e5fc2'],
+      [3, 9, BLUE],
+      [4, 9, '#1e5fc2'],
+      [4, 8, GOLD]
+    )
+  }
+  if (stage >= 14) {
+    pixels.push([6, 0, GOLD], [11, 0, GOLD], [4, 2, GOLD], [13, 2, GOLD])
+  }
+  if (stage >= 16) {
+    pixels.push([6, 13, '#4a2800'], [7, 13, '#4a2800'], [10, 13, '#4a2800'], [11, 13, '#4a2800'])
+    pixels.push([8, 5, '#ff9999'], [9, 5, '#ff9999'])
+  }
+
+  return pixels
+}
+
+export function RpgCanvasVariant({ stage, size, className }: RpgCanvasVariantProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const frameRef = useRef(0)
+  const reducedMotion = useReducedMotion()
+
+  const draw = useCallback(
+    (timestamp: number) => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      const dpr = window.devicePixelRatio || 1
+      const w = 18
+      const h = 18
+      canvas.width = w * dpr * (size / 18)
+      canvas.height = h * dpr * (size / 18)
+      ctx.setTransform(dpr * (size / 18), 0, 0, dpr * (size / 18), 0, 0)
+
+      ctx.clearRect(0, 0, w, h)
+      ctx.imageSmoothingEnabled = false
+
+      // Idle bounce (2-frame animation)
+      const bounce = !reducedMotion && stage >= 3 ? (Math.sin(timestamp / 400) > 0.3 ? -0.5 : 0) : 0
+
+      // Glitch offset for stage 2
+      const glitchX = stage === 2 && !reducedMotion ? Math.sin(timestamp / 50) * 0.5 : 0
+
+      const pixels = getCharacterPixels(stage)
+
+      ctx.save()
+      ctx.translate(glitchX, bounce)
+
+      for (const [x, y, color] of pixels) {
+        ctx.fillStyle = color
+        ctx.fillRect(x, y, 1, 1)
+      }
+
+      ctx.restore()
+
+      // XP bar
+      if (stage >= 3) {
+        const t = stage / 16
+        ctx.fillStyle = '#1a1a2e'
+        ctx.fillRect(1, 16, 16, 1)
+        ctx.fillStyle = BLUE
+        ctx.fillRect(1, 16, 16 * t, 1)
+      }
+
+      frameRef.current = requestAnimationFrame(draw)
+    },
+    [stage, size, reducedMotion]
+  )
+
+  useEffect(() => {
+    frameRef.current = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(frameRef.current)
+  }, [draw])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={cn('transition-all duration-500', className)}
+      style={{
+        width: size,
+        height: size,
+        imageRendering: 'pixelated',
+      }}
+      role="img"
+    />
+  )
+}

--- a/apps/web/src/components/presentation/lyra-story/variants/SilhouetteVariant.tsx
+++ b/apps/web/src/components/presentation/lyra-story/variants/SilhouetteVariant.tsx
@@ -1,0 +1,308 @@
+import { cn, useReducedMotion } from '@repo/ui'
+import { useId } from 'react'
+
+type SilhouetteVariantProps = {
+  stage: number
+  size: number
+  className?: string
+}
+
+// A dark humanoid silhouette that progressively reveals colors, features, details
+export function SilhouetteVariant({ stage, size, className }: SilhouetteVariantProps) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const animate = !reducedMotion
+  const t = stage / 16
+
+  return (
+    <svg
+      viewBox="0 0 100 120"
+      width={size}
+      height={size * 1.2}
+      className={cn('transition-all duration-1000', className)}
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id={`sil-glow-${uid}`} cx="50%" cy="40%" r="60%">
+          <stop offset="0%" stopColor="#2D7FF9" stopOpacity={lerp(0, 0.3, t)} />
+          <stop offset="100%" stopColor="#8B5CF6" stopOpacity="0" />
+        </radialGradient>
+        <filter id={`sil-blur-${uid}`} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="3" />
+        </filter>
+        <clipPath id={`sil-clip-${uid}`}>
+          <path d={SILHOUETTE_PATH} />
+        </clipPath>
+        {/* Reveal mask — circle expanding from center */}
+        <radialGradient id={`sil-reveal-${uid}`} cx="50%" cy="35%" r="50%">
+          <stop offset="0%" stopColor="white" stopOpacity="1" />
+          <stop offset={`${lerp(0, 100, t)}%`} stopColor="white" stopOpacity="1" />
+          <stop offset={`${lerp(5, 100, t)}%`} stopColor="white" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      {/* Background glow */}
+      <circle
+        cx="50"
+        cy="48"
+        r={lerp(10, 50, t)}
+        fill={`url(#sil-glow-${uid})`}
+        className="transition-all duration-1000"
+      />
+
+      {/* Stage 0: Nothing */}
+      {stage === 0 && <circle cx="50" cy="50" r="1" fill="#2D7FF9" opacity="0.3" />}
+
+      {/* Stage 1+: Silhouette appears */}
+      {stage >= 1 && (
+        <g>
+          {/* Dark silhouette base — always visible */}
+          <path
+            d={SILHOUETTE_PATH}
+            fill="#0a0a1a"
+            stroke={stage >= 3 ? '#2D7FF9' : 'none'}
+            strokeWidth={lerp(0, 0.5, (stage - 3) / 13)}
+            opacity={lerp(0.3, 1, Math.min(t * 3, 1))}
+            className="transition-all duration-1000"
+          />
+
+          {/* Color reveal layer — clipped to silhouette, masked by reveal gradient */}
+          {stage >= 4 && (
+            <g clipPath={`url(#sil-clip-${uid})`}>
+              {/* Body gradient fill */}
+              <rect
+                x="0"
+                y="0"
+                width="100"
+                height="120"
+                fill={`url(#sil-reveal-${uid})`}
+                opacity={lerp(0, 0.15, (stage - 4) / 12)}
+              />
+
+              {/* Skin areas (face, hands) */}
+              {stage >= 6 && (
+                <>
+                  {/* Face */}
+                  <ellipse
+                    cx="50"
+                    cy="22"
+                    rx="11"
+                    ry="14"
+                    fill="#e0c8a8"
+                    opacity={lerp(0, 0.8, (stage - 6) / 10)}
+                  />
+                </>
+              )}
+
+              {/* Eyes */}
+              {stage >= 7 && (
+                <>
+                  <circle
+                    cx="45"
+                    cy="20"
+                    r="1.5"
+                    fill="#2D7FF9"
+                    opacity={lerp(0.3, 1, (stage - 7) / 9)}
+                  />
+                  <circle
+                    cx="55"
+                    cy="20"
+                    r="1.5"
+                    fill="#2D7FF9"
+                    opacity={lerp(0.3, 1, (stage - 7) / 9)}
+                  />
+                  {/* Glow behind eyes */}
+                  <circle
+                    cx="45"
+                    cy="20"
+                    r="3"
+                    fill="#2D7FF9"
+                    opacity={lerp(0, 0.2, (stage - 7) / 9)}
+                    filter={`url(#sil-blur-${uid})`}
+                  />
+                  <circle
+                    cx="55"
+                    cy="20"
+                    r="3"
+                    fill="#2D7FF9"
+                    opacity={lerp(0, 0.2, (stage - 7) / 9)}
+                    filter={`url(#sil-blur-${uid})`}
+                  />
+                </>
+              )}
+
+              {/* Clothing details */}
+              {stage >= 8 && (
+                <>
+                  {/* Robe/dress */}
+                  <path
+                    d="M 38 40 L 35 95 L 65 95 L 62 40 Z"
+                    fill="#8B5CF6"
+                    opacity={lerp(0, 0.6, (stage - 8) / 8)}
+                  />
+                  {/* Belt/sash */}
+                  <rect
+                    x="38"
+                    y="52"
+                    width="24"
+                    height="3"
+                    fill="#ffd700"
+                    opacity={lerp(0, 0.5, (stage - 8) / 8)}
+                  />
+                </>
+              )}
+
+              {/* Hair */}
+              {stage >= 9 && (
+                <path
+                  d="M 39 18 Q 42 5 50 3 Q 58 5 61 18 L 63 35 Q 60 38 58 40 L 50 18 L 42 40 Q 40 38 37 35 Z"
+                  fill="#8B5CF6"
+                  opacity={lerp(0, 0.8, (stage - 9) / 7)}
+                />
+              )}
+
+              {/* Mouth */}
+              {stage >= 10 && (
+                <path
+                  d="M 46 26 Q 50 28 54 26"
+                  fill="none"
+                  stroke="#c89878"
+                  strokeWidth="0.8"
+                  opacity={lerp(0, 0.7, (stage - 10) / 6)}
+                />
+              )}
+
+              {/* Hands holding something glowing */}
+              {stage >= 11 && (
+                <>
+                  <circle
+                    cx="32"
+                    cy="65"
+                    r="3"
+                    fill="#e0c8a8"
+                    opacity={lerp(0, 0.6, (stage - 11) / 5)}
+                  />
+                  <circle
+                    cx="68"
+                    cy="65"
+                    r="3"
+                    fill="#e0c8a8"
+                    opacity={lerp(0, 0.6, (stage - 11) / 5)}
+                  />
+                  {/* Glowing orb in hands */}
+                  <circle
+                    cx="50"
+                    cy="62"
+                    r="4"
+                    fill="#2D7FF9"
+                    opacity={lerp(0, 0.4, (stage - 11) / 5)}
+                    filter={`url(#sil-blur-${uid})`}
+                  />
+                  <circle
+                    cx="50"
+                    cy="62"
+                    r="2"
+                    fill="white"
+                    opacity={lerp(0, 0.6, (stage - 11) / 5)}
+                  />
+                </>
+              )}
+            </g>
+          )}
+
+          {/* Crown / identity marker */}
+          {stage >= 12 && (
+            <>
+              <circle
+                cx="50"
+                cy="4"
+                r={lerp(1, 3, (stage - 12) / 4)}
+                fill="#ffd700"
+                opacity={lerp(0.3, 0.8, (stage - 12) / 4)}
+              />
+              <circle
+                cx="45"
+                cy="6"
+                r={lerp(0.5, 1.5, (stage - 12) / 4)}
+                fill="#ffd700"
+                opacity={lerp(0.2, 0.6, (stage - 12) / 4)}
+              />
+              <circle
+                cx="55"
+                cy="6"
+                r={lerp(0.5, 1.5, (stage - 12) / 4)}
+                fill="#ffd700"
+                opacity={lerp(0.2, 0.6, (stage - 12) / 4)}
+              />
+            </>
+          )}
+
+          {/* Aura outline at peak */}
+          {stage >= 14 && (
+            <path
+              d={SILHOUETTE_PATH}
+              fill="none"
+              stroke="#2D7FF9"
+              strokeWidth={lerp(0.5, 1.5, (stage - 14) / 2)}
+              opacity={lerp(0.2, 0.5, (stage - 14) / 2)}
+              filter={`url(#sil-blur-${uid})`}
+              className={cn(animate && 'lyra-core-pulse')}
+            />
+          )}
+
+          {/* Particle effects */}
+          {stage >= 13 && (
+            <>
+              {[
+                { cx: 20, cy: 30 },
+                { cx: 80, cy: 25 },
+                { cx: 15, cy: 70 },
+                { cx: 85, cy: 65 },
+                { cx: 30, cy: 100 },
+                { cx: 70, cy: 95 },
+              ]
+                .slice(0, Math.min(stage - 12, 6))
+                .map((dot) => (
+                  <circle
+                    key={`${dot.cx}-${dot.cy}`}
+                    cx={dot.cx}
+                    cy={dot.cy}
+                    r="1"
+                    fill={dot.cx > 50 ? '#8B5CF6' : '#2D7FF9'}
+                    opacity="0.4"
+                    className={cn(animate && 'lyra-satellite')}
+                  />
+                ))}
+            </>
+          )}
+        </g>
+      )}
+
+      {/* Name label */}
+      {stage >= 9 && (
+        <text
+          x="50"
+          y="115"
+          textAnchor="middle"
+          fontSize="5"
+          fontFamily="monospace"
+          letterSpacing="3"
+          fill="#8B5CF6"
+          opacity={lerp(0, 0.6, (stage - 9) / 7)}
+          className="transition-all duration-1000"
+        >
+          LYRA
+        </text>
+      )}
+    </svg>
+  )
+}
+
+// Humanoid silhouette SVG path — standing figure with flowing hair/dress
+const SILHOUETTE_PATH =
+  'M 50 3 ' +
+  'Q 61 5 62 18 L 63 30 Q 65 35 70 40 L 75 50 Q 76 55 72 58 L 68 60 L 70 75 L 72 95 Q 72 100 68 100 L 60 100 Q 58 100 58 95 L 56 75 L 50 72 L 44 75 L 42 95 Q 42 100 40 100 L 32 100 Q 28 100 28 95 L 30 75 L 32 60 L 28 58 Q 24 55 25 50 L 30 40 Q 35 35 37 30 L 38 18 Q 39 5 50 3 Z'
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}

--- a/apps/web/src/components/presentation/lyra-story/variants/TamagotchiVariant.tsx
+++ b/apps/web/src/components/presentation/lyra-story/variants/TamagotchiVariant.tsx
@@ -1,0 +1,426 @@
+import { cn, useReducedMotion } from '@repo/ui'
+import { useId } from 'react'
+
+type TamagotchiVariantProps = {
+  stage: number
+  size: number
+  className?: string
+}
+
+// Evolution: egg → crack → hatch → baby blob → toddler → child → teen → adult Lyra
+export function TamagotchiVariant({ stage, size, className }: TamagotchiVariantProps) {
+  const uid = useId()
+  const reducedMotion = useReducedMotion()
+  const animate = !reducedMotion
+
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      width={size}
+      height={size}
+      className={cn('transition-all duration-1000', className)}
+      aria-hidden="true"
+      style={{ imageRendering: stage <= 8 ? 'auto' : 'auto' }}
+    >
+      <defs>
+        <filter id={`tama-glow-${uid}`} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="1.5" />
+        </filter>
+      </defs>
+
+      {/* Screen bezel (tamagotchi shell) */}
+      <rect
+        x="1"
+        y="1"
+        width="46"
+        height="46"
+        rx="10"
+        fill="#1a1a2e"
+        stroke="#2D7FF9"
+        strokeWidth="0.5"
+        opacity="0.3"
+      />
+      <rect x="3" y="3" width="42" height="42" rx="8" fill="#0a0a18" />
+
+      {/* Stage 0-1: Egg */}
+      {stage <= 1 && <Egg stage={stage} animate={animate} />}
+
+      {/* Stage 2: Cracking */}
+      {stage === 2 && <CrackingEgg animate={animate} />}
+
+      {/* Stage 3-4: Baby blob */}
+      {(stage === 3 || stage === 4) && <BabyBlob stage={stage} animate={animate} uid={uid} />}
+
+      {/* Stage 5-6: Toddler */}
+      {(stage === 5 || stage === 6) && <Toddler stage={stage} animate={animate} uid={uid} />}
+
+      {/* Stage 7-9: Child */}
+      {stage >= 7 && stage <= 9 && <Child stage={stage} animate={animate} uid={uid} />}
+
+      {/* Stage 10-12: Teen */}
+      {stage >= 10 && stage <= 12 && <Teen stage={stage} animate={animate} uid={uid} />}
+
+      {/* Stage 13-16: Adult Lyra */}
+      {stage >= 13 && <Adult stage={stage} animate={animate} uid={uid} />}
+
+      {/* Hearts / mood indicator */}
+      {stage >= 3 && <MoodIndicator stage={stage} />}
+
+      {/* Stats bar */}
+      <rect x="6" y="42" width="36" height="2" rx="1" fill="#1a1a2e" />
+      <rect
+        x="6"
+        y="42"
+        width={36 * (stage / 16)}
+        height="2"
+        rx="1"
+        fill="#2D7FF9"
+        className="transition-all duration-1000"
+      />
+    </svg>
+  )
+}
+
+function Egg({ stage, animate }: { stage: number; animate: boolean }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-wobble')}>
+      {/* Egg shape */}
+      <ellipse cx="24" cy="26" rx="8" ry="10" fill="#e8e0d0" />
+      <ellipse cx="24" cy="26" rx="8" ry="10" fill="none" stroke="#c8b890" strokeWidth="0.5" />
+      {/* Spots */}
+      <circle cx="21" cy="24" r="1.5" fill="#2D7FF9" opacity="0.3" />
+      <circle cx="27" cy="28" r="1" fill="#8B5CF6" opacity="0.3" />
+      {/* Sparkle on stage 1 */}
+      {stage >= 1 && (
+        <>
+          <text x="30" y="20" fontSize="4" className={cn(animate && 'lyra-tama-sparkle')}>
+            *
+          </text>
+        </>
+      )}
+    </g>
+  )
+}
+
+function CrackingEgg({ animate }: { animate: boolean }) {
+  return (
+    <g className={cn(animate && 'lyra-glitch')}>
+      {/* Egg with cracks */}
+      <ellipse cx="24" cy="26" rx="8" ry="10" fill="#e8e0d0" />
+      {/* Crack lines */}
+      <path d="M 20 24 L 24 26 L 22 30" fill="none" stroke="#8B5CF6" strokeWidth="0.5" />
+      <path d="M 28 22 L 26 26 L 29 28" fill="none" stroke="#2D7FF9" strokeWidth="0.5" />
+      {/* Light peeking through */}
+      <circle cx="24" cy="26" r="2" fill="#2D7FF9" opacity="0.4" />
+      {/* Particles */}
+      <rect x="19" y="20" width="1" height="1" fill="#e8e0d0" opacity="0.6" />
+      <rect x="28" y="22" width="1" height="1" fill="#e8e0d0" opacity="0.5" />
+    </g>
+  )
+}
+
+function BabyBlob({ stage, animate, uid }: { stage: number; animate: boolean; uid: string }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Blob body */}
+      <ellipse cx="24" cy="28" rx="7" ry="6" fill="#2D7FF9" />
+      <ellipse
+        cx="24"
+        cy="28"
+        rx="7"
+        ry="6"
+        fill="#2D7FF9"
+        filter={`url(#tama-glow-${uid})`}
+        opacity="0.3"
+      />
+      {/* Eyes — big and cute */}
+      <circle cx="21" cy="26" r="2" fill="white" />
+      <circle cx="27" cy="26" r="2" fill="white" />
+      <circle cx="22" cy="26" r="1" fill="#1a1a3e" />
+      <circle cx="28" cy="26" r="1" fill="#1a1a3e" />
+      {/* Eye highlights */}
+      <circle cx="22.5" cy="25.5" r="0.4" fill="white" />
+      <circle cx="28.5" cy="25.5" r="0.4" fill="white" />
+      {/* Mouth */}
+      {stage >= 4 && (
+        <path d="M 22 30 Q 24 32 26 30" fill="none" stroke="#1a1a3e" strokeWidth="0.5" />
+      )}
+      {/* Blush */}
+      <circle cx="18" cy="28" r="1.5" fill="#ff9999" opacity="0.3" />
+      <circle cx="30" cy="28" r="1.5" fill="#ff9999" opacity="0.3" />
+    </g>
+  )
+}
+
+function Toddler({ stage, animate, uid }: { stage: number; animate: boolean; uid: string }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Body — rounder, with tiny legs */}
+      <ellipse cx="24" cy="26" rx="7" ry="7" fill="#2D7FF9" />
+      <ellipse
+        cx="24"
+        cy="26"
+        rx="7"
+        ry="7"
+        fill="#2D7FF9"
+        filter={`url(#tama-glow-${uid})`}
+        opacity="0.2"
+      />
+      {/* Tiny legs */}
+      <rect x="20" y="32" width="2" height="3" rx="1" fill="#1e5fc2" />
+      <rect x="26" y="32" width="2" height="3" rx="1" fill="#1e5fc2" />
+      {/* Arms (stage 6) */}
+      {stage >= 6 && (
+        <>
+          <rect x="15" y="25" width="3" height="2" rx="1" fill="#2D7FF9" />
+          <rect x="30" y="25" width="3" height="2" rx="1" fill="#2D7FF9" />
+        </>
+      )}
+      {/* Face */}
+      <circle cx="21" cy="24" r="2" fill="white" />
+      <circle cx="27" cy="24" r="2" fill="white" />
+      <circle cx="22" cy="24" r="1" fill="#1a1a3e" />
+      <circle cx="28" cy="24" r="1" fill="#1a1a3e" />
+      <circle cx="22.5" cy="23.5" r="0.4" fill="white" />
+      <circle cx="28.5" cy="23.5" r="0.4" fill="white" />
+      <path d="M 22 28 Q 24 30 26 28" fill="none" stroke="#1a1a3e" strokeWidth="0.5" />
+      {/* Blush */}
+      <circle cx="18" cy="26" r="1.5" fill="#ff9999" opacity="0.3" />
+      <circle cx="30" cy="26" r="1.5" fill="#ff9999" opacity="0.3" />
+      {/* Hair tuft */}
+      <path d="M 22 18 Q 24 16 26 18" fill="#8B5CF6" />
+    </g>
+  )
+}
+
+function Child({ stage, animate, uid }: { stage: number; animate: boolean; uid: string }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Head */}
+      <circle cx="24" cy="20" r="7" fill="#2D7FF9" />
+      {/* Body */}
+      <rect x="20" y="26" width="8" height="6" rx="2" fill="#8B5CF6" />
+      {/* Legs */}
+      <rect x="20" y="32" width="3" height="4" rx="1" fill="#1a1a3e" />
+      <rect x="25" y="32" width="3" height="4" rx="1" fill="#1a1a3e" />
+      {/* Arms */}
+      <rect x="14" y="27" width="5" height="2" rx="1" fill="#2D7FF9" />
+      <rect x="29" y="27" width="5" height="2" rx="1" fill="#2D7FF9" />
+      {/* Face */}
+      <circle cx="21" cy="19" r="1.5" fill="white" />
+      <circle cx="27" cy="19" r="1.5" fill="white" />
+      <circle cx="21.5" cy="19" r="0.8" fill="#1a1a3e" />
+      <circle cx="27.5" cy="19" r="0.8" fill="#1a1a3e" />
+      <path d="M 22 23 Q 24 25 26 23" fill="none" stroke="white" strokeWidth="0.5" />
+      {/* Hair */}
+      <path d="M 17 18 Q 19 12 24 11 Q 29 12 31 18" fill="#8B5CF6" />
+      <circle cx="24" cy="12" r="1" fill="#ffd700" opacity={stage >= 9 ? 1 : 0} />
+      {/* Aura glow at stage 8+ */}
+      {stage >= 8 && (
+        <circle
+          cx="24"
+          cy="24"
+          r="18"
+          fill="#2D7FF9"
+          filter={`url(#tama-glow-${uid})`}
+          opacity="0.06"
+        />
+      )}
+    </g>
+  )
+}
+
+function Teen({ stage, animate, uid }: { stage: number; animate: boolean; uid: string }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Taller body */}
+      <circle cx="24" cy="16" r="6" fill="#2D7FF9" />
+      <rect x="20" y="21" width="8" height="8" rx="2" fill="#8B5CF6" />
+      <rect x="19" y="29" width="4" height="6" rx="1" fill="#1a1a3e" />
+      <rect x="25" y="29" width="4" height="6" rx="1" fill="#1a1a3e" />
+      {/* Arms */}
+      <rect x="13" y="22" width="6" height="2" rx="1" fill="#2D7FF9" />
+      <rect x="29" y="22" width="6" height="2" rx="1" fill="#2D7FF9" />
+      {/* Face */}
+      <circle cx="22" cy="15" r="1.2" fill="white" />
+      <circle cx="26" cy="15" r="1.2" fill="white" />
+      <circle cx="22.3" cy="15" r="0.6" fill="#2D7FF9" />
+      <circle cx="26.3" cy="15" r="0.6" fill="#2D7FF9" />
+      <path d="M 22 18 Q 24 19.5 26 18" fill="none" stroke="white" strokeWidth="0.5" />
+      {/* Hair (longer) */}
+      <path d="M 18 15 Q 20 8 24 7 Q 28 8 30 15" fill="#8B5CF6" />
+      <path d="M 18 15 Q 17 20 16 22" fill="none" stroke="#8B5CF6" strokeWidth="1.5" />
+      <path d="M 30 15 Q 31 20 32 22" fill="none" stroke="#8B5CF6" strokeWidth="1.5" />
+      {/* Crown */}
+      {stage >= 10 && (
+        <>
+          <circle cx="24" cy="7" r="1.5" fill="#ffd700" />
+          <circle cx="21" cy="8" r="0.8" fill="#ffd700" opacity="0.7" />
+          <circle cx="27" cy="8" r="0.8" fill="#ffd700" opacity="0.7" />
+        </>
+      )}
+      {/* Cape */}
+      {stage >= 11 && (
+        <path d="M 18 21 Q 14 30 12 36 L 36 36 Q 34 30 30 21" fill="#8B5CF6" opacity="0.3" />
+      )}
+      {/* Companion orbs */}
+      {stage >= 12 && (
+        <>
+          <circle cx="8" cy="14" r="1.5" fill="#2D7FF9" opacity="0.6" />
+          <circle cx="40" cy="14" r="1.5" fill="#8B5CF6" opacity="0.6" />
+        </>
+      )}
+      {/* Aura */}
+      <circle
+        cx="24"
+        cy="22"
+        r="20"
+        fill="#8B5CF6"
+        filter={`url(#tama-glow-${uid})`}
+        opacity="0.04"
+      />
+    </g>
+  )
+}
+
+function Adult({ stage, animate, uid }: { stage: number; animate: boolean; uid: string }) {
+  return (
+    <g className={cn(animate && 'lyra-tama-bounce')}>
+      {/* Full character — elegantly proportioned */}
+      {/* Head */}
+      <circle cx="24" cy="13" r="5.5" fill="#2D7FF9" />
+      {/* Body (dress/robe) */}
+      <path d="M 19 18 L 18 35 L 30 35 L 29 18 Z" fill="#8B5CF6" rx="2" />
+      <path d="M 20 18 L 19 35 L 29 35 L 28 18 Z" fill="#6d3fc4" />
+      {/* Arms */}
+      <path d="M 19 19 L 13 24 L 14 25 L 19 21" fill="#2D7FF9" />
+      <path d="M 29 19 L 35 24 L 34 25 L 29 21" fill="#2D7FF9" />
+      {/* Hands — glowing */}
+      <circle cx="13" cy="24" r="1.5" fill="#e0c8a8" />
+      <circle cx="35" cy="24" r="1.5" fill="#e0c8a8" />
+      {/* Face */}
+      <circle cx="22" cy="12" r="1" fill="white" />
+      <circle cx="26" cy="12" r="1" fill="white" />
+      <circle cx="22.3" cy="12" r="0.5" fill="#2D7FF9" />
+      <circle cx="26.3" cy="12" r="0.5" fill="#2D7FF9" />
+      <path d="M 22 15 Q 24 16.5 26 15" fill="none" stroke="white" strokeWidth="0.4" />
+      {/* Hair — long flowing */}
+      <path d="M 18.5 12 Q 20 5 24 4 Q 28 5 29.5 12" fill="#8B5CF6" />
+      <path
+        d="M 18.5 12 Q 16 20 14 28"
+        fill="none"
+        stroke="#8B5CF6"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M 29.5 12 Q 32 20 34 28"
+        fill="none"
+        stroke="#8B5CF6"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      {/* Crown */}
+      <circle cx="24" cy="5" r="2" fill="#ffd700" />
+      <circle cx="21" cy="6" r="1" fill="#ffd700" opacity="0.7" />
+      <circle cx="27" cy="6" r="1" fill="#ffd700" opacity="0.7" />
+      {/* Cape */}
+      <path d="M 19 18 Q 12 28 10 36 L 38 36 Q 36 28 29 18" fill="#8B5CF6" opacity="0.25" />
+      {/* Aura — grows with stage */}
+      <circle
+        cx="24"
+        cy="22"
+        r={lerp(14, 20, (stage - 13) / 3)}
+        fill="#2D7FF9"
+        filter={`url(#tama-glow-${uid})`}
+        opacity={lerp(0.04, 0.1, (stage - 13) / 3)}
+      />
+      {/* Companion orbs */}
+      {stage >= 14 && (
+        <>
+          <circle
+            cx="6"
+            cy="10"
+            r="1.5"
+            fill="#2D7FF9"
+            opacity="0.6"
+            className={cn(animate && 'lyra-satellite')}
+          />
+          <circle
+            cx="42"
+            cy="10"
+            r="1.5"
+            fill="#8B5CF6"
+            opacity="0.6"
+            className={cn(animate && 'lyra-satellite')}
+          />
+          <circle
+            cx="6"
+            cy="30"
+            r="1"
+            fill="#8B5CF6"
+            opacity="0.4"
+            className={cn(animate && 'lyra-satellite')}
+          />
+          <circle
+            cx="42"
+            cy="30"
+            r="1"
+            fill="#2D7FF9"
+            opacity="0.4"
+            className={cn(animate && 'lyra-satellite')}
+          />
+        </>
+      )}
+      {/* Sparkles at peak */}
+      {stage >= 15 && (
+        <>
+          <text
+            x="8"
+            y="8"
+            fontSize="3"
+            fill="#ffd700"
+            opacity="0.6"
+            className={cn(animate && 'lyra-tama-sparkle')}
+          >
+            *
+          </text>
+          <text
+            x="38"
+            y="18"
+            fontSize="3"
+            fill="#ffd700"
+            opacity="0.6"
+            className={cn(animate && 'lyra-tama-sparkle')}
+          >
+            *
+          </text>
+        </>
+      )}
+    </g>
+  )
+}
+
+function MoodIndicator({ stage }: { stage: number }) {
+  const hearts = Math.min(Math.floor(stage / 4) + 1, 4)
+  return (
+    <g>
+      {Array.from({ length: hearts }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static heart indicator
+        <text
+          key={i}
+          x={8 + i * 5}
+          y="8"
+          fontSize="3.5"
+          fill={i < hearts - 1 ? '#ff6b9d' : '#ff6b9d80'}
+        >
+          {'\u2665'}
+        </text>
+      ))}
+    </g>
+  )
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}

--- a/apps/web/src/routes/talks/lyra-companion-test.lazy.tsx
+++ b/apps/web/src/routes/talks/lyra-companion-test.lazy.tsx
@@ -1,0 +1,342 @@
+import { cn } from '@repo/ui'
+import { createLazyFileRoute } from '@tanstack/react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { LyraCompanion, type LyraVariant } from '@/components/presentation/lyra-story/LyraCompanion'
+
+export const Route = createLazyFileRoute('/talks/lyra-companion-test')({
+  component: LyraCompanionTestPage,
+})
+
+const SLIDE_LABELS = [
+  'Title — Empty void',
+  'Simple Idea — Spark',
+  'Breaking Things — Glitch',
+  'Building Habits — Stable pulse',
+  'The Brain — Core forms',
+  'The Messenger — 2 rings',
+  'Letting Go — Shedding',
+  'The Voice — Wave appears',
+  'The Night — Bloom',
+  'Finding Name — "L" letter',
+  'The Character — Full orbital',
+  'The Ecosystem — Satellites',
+  'The Numbers — Data sparkles',
+  'Character Sheet — RPG frame',
+  'The Lesson — Full radiance',
+  'Next Steps — Forward',
+  'Closing — Serene',
+]
+
+const VARIANTS: LyraVariant[] = [
+  'quantum',
+  'constellation',
+  'rpg-canvas',
+  'tamagotchi',
+  'silhouette',
+  'blob',
+  'pokemon',
+]
+
+const VARIANT_LABELS: Record<LyraVariant, string> = {
+  quantum: 'Quantum',
+  constellation: 'Stars',
+  'rpg-canvas': 'RPG',
+  tamagotchi: 'Tamagotchi',
+  silhouette: 'Silhouette',
+  blob: 'Blob',
+  pokemon: 'Pokemon',
+}
+
+const POSITIONS = ['bottom-right', 'bottom-left', 'top-right', 'top-left'] as const
+type Position = (typeof POSITIONS)[number]
+
+const SIZES = [48, 64, 80, 100, 120] as const
+
+function LyraCompanionTestPage() {
+  const [variant, setVariant] = useState<LyraVariant>('quantum')
+  const [position, setPosition] = useState<Position>('bottom-right')
+  const [size, setSize] = useState<number>(80)
+  const [stage, setStage] = useState(0)
+  const [bgMode, setBgMode] = useState<'dark' | 'light'>('dark')
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const sectionRefs = useRef<(HTMLElement | null)[]>([])
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const index = Number((entry.target as HTMLElement).dataset.index)
+            if (!Number.isNaN(index)) setStage(index)
+          }
+        }
+      },
+      { root: container, threshold: 0.5 }
+    )
+
+    for (const section of sectionRefs.current) {
+      if (section) observer.observe(section)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  const setSectionRef = useCallback(
+    (index: number) => (el: HTMLElement | null) => {
+      sectionRefs.current[index] = el
+    },
+    []
+  )
+
+  const positionClasses: Record<Position, string> = {
+    'bottom-right': 'bottom-6 right-6',
+    'bottom-left': 'bottom-6 left-6',
+    'top-right': 'top-20 right-6',
+    'top-left': 'top-20 left-6',
+  }
+
+  const isDark = bgMode === 'dark'
+
+  return (
+    <div
+      className={cn(
+        'relative min-h-dvh',
+        isDark ? 'bg-[#0a0a1a] text-gray-100' : 'bg-white text-gray-900'
+      )}
+    >
+      {/* Control Panel — fixed top */}
+      <div
+        className={cn(
+          'fixed top-0 left-0 right-0 z-50 px-4 py-2 backdrop-blur-xl border-b',
+          isDark ? 'bg-gray-900/80 border-gray-700/50' : 'bg-white/80 border-gray-200'
+        )}
+      >
+        <div className="mx-auto max-w-7xl flex flex-wrap items-center gap-3 text-sm">
+          <span className={cn('font-bold', isDark ? 'text-blue-400' : 'text-blue-600')}>
+            Lyra Companion
+          </span>
+          <span className={cn('font-mono text-xs', isDark ? 'text-gray-500' : 'text-gray-400')}>
+            {stage}/16
+          </span>
+
+          {/* Variant selector — scrollable row */}
+          <div className="flex items-center gap-1 overflow-x-auto">
+            {VARIANTS.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setVariant(v)}
+                className={cn(
+                  'px-2 py-1 rounded text-[11px] font-mono transition-colors whitespace-nowrap',
+                  variant === v
+                    ? isDark
+                      ? 'bg-blue-500/20 text-blue-300 border border-blue-500/40'
+                      : 'bg-blue-100 text-blue-700 border border-blue-300'
+                    : isDark
+                      ? 'text-gray-400 hover:text-gray-200 border border-transparent'
+                      : 'text-gray-500 hover:text-gray-700 border border-transparent'
+                )}
+              >
+                {VARIANT_LABELS[v]}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-2 ml-auto">
+            {/* Position */}
+            <select
+              value={position}
+              onChange={(e) => setPosition(e.target.value as Position)}
+              className={cn(
+                'text-xs rounded px-1.5 py-1 border',
+                isDark
+                  ? 'bg-gray-800 border-gray-700 text-gray-200'
+                  : 'bg-white border-gray-300 text-gray-700'
+              )}
+            >
+              {POSITIONS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+
+            {/* Size */}
+            <div className="flex gap-0.5">
+              {SIZES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setSize(s)}
+                  className={cn(
+                    'px-1.5 py-1 rounded text-[11px] font-mono transition-colors',
+                    size === s
+                      ? isDark
+                        ? 'bg-purple-500/20 text-purple-300 border border-purple-500/40'
+                        : 'bg-purple-100 text-purple-700 border border-purple-300'
+                      : isDark
+                        ? 'text-gray-400 hover:text-gray-200 border border-transparent'
+                        : 'text-gray-500 hover:text-gray-700 border border-transparent'
+                  )}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+
+            {/* BG toggle */}
+            <button
+              type="button"
+              onClick={() => setBgMode(bgMode === 'dark' ? 'light' : 'dark')}
+              className={cn(
+                'px-2 py-1 rounded text-xs border transition-colors',
+                isDark
+                  ? 'border-gray-700 text-gray-300 hover:bg-gray-800'
+                  : 'border-gray-300 text-gray-600 hover:bg-gray-100'
+              )}
+            >
+              {isDark ? 'Light' : 'Dark'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Fixed Companion */}
+      <div className={cn('fixed z-40 transition-all duration-500', positionClasses[position])}>
+        <div
+          className={cn(
+            'rounded-xl p-2 backdrop-blur-sm transition-all duration-1000',
+            isDark ? 'bg-gray-900/50' : 'bg-white/50 shadow-lg'
+          )}
+        >
+          <LyraCompanion stage={stage} variant={variant} size={size} />
+        </div>
+        <div
+          className={cn(
+            'mt-1 text-center text-[10px] font-mono transition-colors',
+            isDark ? 'text-gray-600' : 'text-gray-400'
+          )}
+        >
+          {VARIANT_LABELS[variant]} {stage}/16
+        </div>
+      </div>
+
+      {/* Bottom strip — all variants */}
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40">
+        <div
+          className={cn(
+            'flex gap-2 rounded-2xl px-3 py-2 backdrop-blur-xl border',
+            isDark ? 'bg-gray-900/70 border-gray-700/50' : 'bg-white/70 border-gray-200'
+          )}
+        >
+          {VARIANTS.map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setVariant(v)}
+              className={cn(
+                'rounded-lg p-1 transition-all flex flex-col items-center gap-1',
+                variant === v
+                  ? isDark
+                    ? 'ring-2 ring-blue-500/50 bg-blue-500/10'
+                    : 'ring-2 ring-blue-400 bg-blue-50'
+                  : isDark
+                    ? 'hover:bg-gray-800/50'
+                    : 'hover:bg-gray-100'
+              )}
+            >
+              <LyraCompanion stage={stage} variant={v} size={40} />
+              <span
+                className={cn('text-[9px] font-mono', isDark ? 'text-gray-500' : 'text-gray-400')}
+              >
+                {VARIANT_LABELS[v]}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Scrollable sections */}
+      <div ref={scrollContainerRef} className="h-dvh overflow-y-auto snap-y snap-mandatory pt-12">
+        {SLIDE_LABELS.map((label, index) => (
+          <section
+            key={label}
+            ref={setSectionRef(index)}
+            data-index={index}
+            className="h-dvh snap-start flex flex-col items-center justify-center px-6 relative"
+          >
+            <div
+              className={cn(
+                'absolute top-16 left-6 font-mono text-xs',
+                isDark ? 'text-gray-700' : 'text-gray-300'
+              )}
+            >
+              {String(index + 1).padStart(2, '0')} / 17
+            </div>
+
+            {/* Stage dots */}
+            <div className="absolute right-6 top-1/2 -translate-y-1/2 flex flex-col gap-1.5">
+              {SLIDE_LABELS.map((_, i) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static dot indicator
+                  key={i}
+                  className={cn(
+                    'h-1.5 w-1.5 rounded-full transition-all duration-300',
+                    i === stage
+                      ? isDark
+                        ? 'bg-blue-400 scale-150'
+                        : 'bg-blue-500 scale-150'
+                      : i < stage
+                        ? isDark
+                          ? 'bg-blue-400/30'
+                          : 'bg-blue-300/50'
+                        : isDark
+                          ? 'bg-gray-700'
+                          : 'bg-gray-300'
+                  )}
+                />
+              ))}
+            </div>
+
+            <div className="max-w-2xl text-center space-y-4">
+              <div
+                className={cn(
+                  'text-6xl font-bold tabular-nums font-mono',
+                  isDark
+                    ? 'bg-gradient-to-br from-blue-400 to-purple-400 bg-clip-text text-transparent'
+                    : 'bg-gradient-to-br from-blue-600 to-purple-600 bg-clip-text text-transparent'
+                )}
+              >
+                {String(index).padStart(2, '0')}
+              </div>
+              <h2
+                className={cn(
+                  'text-2xl font-bold tracking-tight lg:text-3xl',
+                  isDark ? 'text-gray-100' : 'text-gray-900'
+                )}
+              >
+                {label.split(' — ')[0]}
+              </h2>
+              <p className={cn('text-lg italic', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                {label.split(' — ')[1]}
+              </p>
+              <div
+                className={cn(
+                  'mt-8 rounded-lg border px-6 py-4 text-sm font-mono',
+                  isDark
+                    ? 'border-gray-800 bg-gray-900/50 text-gray-500'
+                    : 'border-gray-200 bg-gray-50 text-gray-400'
+                )}
+              >
+                stage={index} &middot; t={Number((index / 16).toFixed(2))}
+              </div>
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/talks/lyra-companion-test.tsx
+++ b/apps/web/src/routes/talks/lyra-companion-test.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/talks/lyra-companion-test')({})

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -268,6 +268,128 @@ html.dark .shiki span {
   }
 }
 
+/* ─── Lyra Companion animations ─── */
+@keyframes lyra-core-pulse {
+  0%, 100% { opacity: 0.15; r: inherit; }
+  50% { opacity: 0.25; }
+}
+
+@keyframes lyra-ring-spin1 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes lyra-ring-spin2 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(-360deg); }
+}
+
+@keyframes lyra-ring-spin3 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes lyra-electron-orbit {
+  0% { transform: rotate(0deg) translateX(8px) rotate(0deg); }
+  100% { transform: rotate(360deg) translateX(8px) rotate(-360deg); }
+}
+
+@keyframes lyra-glitch-shake {
+  0%, 100% { transform: translate(0); filter: none; }
+  10% { transform: translate(-2px, 1px); }
+  20% { transform: translate(2px, -1px); filter: hue-rotate(90deg); }
+  30% { transform: translate(-1px, 2px); }
+  40% { transform: translate(1px, -2px); filter: hue-rotate(-90deg); }
+  50% { transform: translate(0); }
+}
+
+@keyframes lyra-wave-flow {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-20px); }
+}
+
+@keyframes lyra-satellite-orbit {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 0.8; }
+}
+
+@keyframes lyra-aura-peak-pulse {
+  0%, 100% { opacity: 0.15; r: 42; }
+  50% { opacity: 0.3; r: 45; }
+}
+
+@keyframes lyra-star-twinkle {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes lyra-glitch-text {
+  0%, 100% { opacity: 1; transform: none; }
+  15% { opacity: 0.6; transform: translateX(-1px) skewX(-5deg); }
+  30% { opacity: 0.8; transform: translateX(1px) skewX(3deg); }
+  45% { opacity: 0.4; }
+  60% { opacity: 0.9; transform: translateX(-1px); }
+}
+
+.lyra-core-pulse { animation: lyra-core-pulse 3s ease-in-out infinite; }
+.lyra-ring1 { animation: lyra-ring-spin1 10s linear infinite; }
+.lyra-ring2 { animation: lyra-ring-spin2 12s linear infinite; }
+.lyra-ring3 { animation: lyra-ring-spin3 15s linear infinite; }
+.lyra-electron-1 { animation: lyra-electron-orbit 4s linear infinite; }
+.lyra-electron-2 { animation: lyra-electron-orbit 5s linear infinite reverse; }
+.lyra-electron-3 { animation: lyra-electron-orbit 6s linear infinite; }
+.lyra-glitch { animation: lyra-glitch-shake 0.8s ease-in-out infinite; }
+.lyra-wave { animation: lyra-wave-flow 3s linear infinite; }
+.lyra-satellite { animation: lyra-satellite-orbit 2s ease-in-out infinite; }
+.lyra-aura-peak { animation: lyra-aura-peak-pulse 2s ease-in-out infinite; }
+.lyra-star-pulse { animation: lyra-star-twinkle 2s ease-in-out infinite; }
+.lyra-glitch-text { animation: lyra-glitch-text 0.6s ease-in-out infinite; }
+
+/* RPG idle bounce */
+@keyframes lyra-rpg-idle {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-1px); }
+}
+.lyra-rpg-idle { animation: lyra-rpg-idle 0.8s ease-in-out infinite; }
+
+/* Tamagotchi animations */
+@keyframes lyra-tama-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2px); }
+}
+@keyframes lyra-tama-wobble {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(-3deg); }
+  75% { transform: rotate(3deg); }
+}
+@keyframes lyra-tama-sparkle {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.3); }
+}
+.lyra-tama-bounce { animation: lyra-tama-bounce 0.6s ease-in-out infinite; }
+.lyra-tama-wobble { animation: lyra-tama-wobble 1.5s ease-in-out infinite; }
+.lyra-tama-sparkle { animation: lyra-tama-sparkle 1s ease-in-out infinite; }
+
+/* Blob morph */
+@keyframes lyra-blob-morph {
+  0%, 100% { transform: scale(1) rotate(0deg); }
+  33% { transform: scale(1.02) rotate(1deg); }
+  66% { transform: scale(0.98) rotate(-1deg); }
+}
+.lyra-blob-morph { animation: lyra-blob-morph 4s ease-in-out infinite; }
+
+/* Blob tendrils */
+@keyframes lyra-tendril-sway1 {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(3deg); }
+}
+@keyframes lyra-tendril-sway2 {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-3deg); }
+}
+.lyra-tendril-1 { animation: lyra-tendril-sway1 3s ease-in-out infinite; transform-origin: top center; }
+.lyra-tendril-2 { animation: lyra-tendril-sway2 3.5s ease-in-out infinite; transform-origin: top center; }
+
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   html {


### PR DESCRIPTION
## Summary

- Add `LyraCompanion` component with 7 visual variants that evolve across 17 stages (0-16), matching the Lyra origin story presentation slides
- **Variants:** Quantum (orbital), Constellation (stars), RPG Canvas (pixel art), Tamagotchi (virtual pet), Silhouette (reveal), Blob (morph), Pokemon (creature evolution)
- Add test page at `/talks/lyra-companion-test` with controls for variant selection, position, size, and dark/light mode
- All variants respect `prefers-reduced-motion` for accessibility

## Test plan

- [ ] Navigate to `/talks/lyra-companion-test`
- [ ] Scroll through all 17 sections, verify companion evolves
- [ ] Switch between all 7 variants using top bar and bottom strip
- [ ] Toggle dark/light mode
- [ ] Change position (4 corners) and size (48-120px)
- [ ] Verify no animation when `prefers-reduced-motion` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>