### PR TITLE
fix(ci): add contents:read to merge-reports job permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,7 @@ jobs:
     needs: [e2e-matrix]
     if: always() && needs.e2e-matrix.result != 'skipped'
     permissions:
+      contents: read
       actions: read
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add `contents: read` to the `merge-reports` job-level permissions block in `ci.yml`
- Job-level `permissions` fully override the top-level block; without `contents: read`, the `actions/checkout` step fails on private forks with "Repository not found"

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #459: fix(ci): add contents:read to merge-reports job permissions | Open |
| Implementation | 1 commit on `feat/459-fix-merge-reports-permissions` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Verify CI passes on this PR (public repo — no behaviour change expected)
- [ ] Fork the repo privately and confirm `merge-reports` checkout no longer fails

Closes #459

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`