### PR TITLE
fix(docs): use turbo-ignore for Vercel ignoreCommand

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || git diff $VERCEL_GIT_PREVIOUS_SHA --quiet -- apps/docs",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || npx turbo-ignore @repo/docs",
   "installCommand": "bun install --ignore-scripts",
   "buildCommand": "bun run codegen && next build"
 }

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -479,13 +479,10 @@ Build settings are version-controlled in `vercel.json` files — no dashboard co
 
 ```json
 {
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || git diff $VERCEL_GIT_PREVIOUS_SHA --quiet -- apps/docs",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || npx turbo-ignore @repo/docs",
   "installCommand": "bun install --ignore-scripts",
   "buildCommand": "bun run codegen && next build"
 }
-```
-
-> **Note:** `apps/docs` uses a `git diff` path filter for `ignoreCommand` instead of `turbo-ignore`, since it is a Next.js app with its own build pipeline rather than a Turbo task graph dependency.
 
 Nitro (TanStack Start) outputs to `.vercel/output/` using the Vercel Build Output API — no `outputDirectory` override needed.
 


### PR DESCRIPTION
## Summary
- Replace `git diff $VERCEL_GIT_PREVIOUS_SHA` with `turbo-ignore @repo/docs` in `apps/docs/vercel.json`
- `VERCEL_GIT_PREVIOUS_SHA` is empty when no prior successful deploy exists, causing all production builds to be canceled
- `turbo-ignore` compares against the last successful Vercel deployment and handles the bootstrap case correctly
- Update deployment docs to match

## Test plan
- [ ] Merge to staging, then promote to main — verify docs production build is no longer canceled on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)