### PR TITLE
docs: sync proxy and ignoreCommand references

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -64,7 +64,7 @@ bun run codegen    # paraglide compile + tsr generate
 
 ## Key Dependencies
 
-TanStack Router + Start + Query + Form + Table | shadcn/ui (Radix) | Lucide icons | Sonner toasts | better-auth | Nitro (dev proxy to API :4000)
+TanStack Router + Start + Query + Form + Table | shadcn/ui (Radix) | Lucide icons | Sonner toasts | better-auth | Nitro (proxy to API via server route)
 
 ## Standards
 
@@ -78,5 +78,5 @@ Vercel (TanStack/Nitro) — `main` = prod, `staging` = preview.
 
 - Paraglide i18n: compiled during codegen, `src/paraglide/` is gitignored. Run `bun run codegen` after changing messages.
 - `routeTree.gen.ts` is auto-generated — never edit manually. Run `bun run codegen` or `tsr generate`.
-- Nitro dev proxy forwards `/api` to `localhost:4000` — API must be running.
+- Nitro server route (`server/routes/api/[...path].ts`) proxies `/api` to `localhost:4000` — API must be running.
 - Env validation: `VITE_*` vars validated at build time via Zod schema in `vite.config.ts`.

--- a/docs/architecture/auth-security.mdx
+++ b/docs/architecture/auth-security.mdx
@@ -288,23 +288,20 @@ Credentials are always enabled (`credentials: true`) because authentication reli
 
 ### Same-Origin Cookie Strategy
 
-In development, the frontend (port 3000) and API (port 4000) run on different ports. Cross-port cookies would require `SameSite=None` and HTTPS, which is impractical for local development. Instead, the frontend uses a **Nitro dev proxy**:
+In development, the frontend (port 3000) and API (port 4000) run on different ports. Cross-port cookies would require `SameSite=None` and HTTPS, which is impractical for local development. Instead, the frontend uses a **Nitro server route** (`server/routes/api/[...path].ts`) that proxies `/api/**` requests to the API using h3's `proxyRequest()`:
 
 ```ts
-// apps/web/vite.config.ts
-nitro({
-  config: {
-    devProxy: {
-      '/api/**': { target: apiTarget, changeOrigin: true },
-    },
-    routeRules: {
-      '/api/**': { proxy: `${apiTarget}/api/**` },
-    },
-  },
+// apps/web/server/routes/api/[...path].ts
+export default defineEventHandler((event) => {
+  const apiTarget = process.env.API_URL ?? `http://localhost:${process.env.API_PORT ?? 4000}`
+  const path = event.context.params?.path ?? ''
+  return proxyRequest(event, `${apiTarget}/api/${path}`)
 })
 ```
 
 The browser sends requests to `localhost:3000/api/*`, which Nitro proxies to the API. Cookies are set on `localhost:3000` (same origin as the frontend), avoiding cross-origin cookie issues entirely.
+
+> **Note:** Do not use Nitro's `devProxy` — it uses `http-proxy` via h3's `fromNodeHandler`, which merges multiple `Set-Cookie` headers into a single comma-joined string, corrupting multi-cookie responses (e.g. better-auth's session + activeOrganizationId).
 
 In production, both apps deploy to Vercel on the same domain, so cookies work natively without proxying.
 

--- a/docs/architecture/ci-cd.mdx
+++ b/docs/architecture/ci-cd.mdx
@@ -380,7 +380,7 @@ flowchart TD
     A3 --> A4["4. turbo run build"]
     A4 --> A5["5. Deploy NestJS function"]
 
-    D --> D1["1. ignoreCommand check<br/>(is this main? did apps/docs change?)"]
+    D --> D1["1. ignoreCommand check<br/>(is this main? did @repo/docs change?)"]
     D1 --> D2["2. bun install"]
     D2 --> D3["3. bun run codegen<br/>(Fumadocs source map)"]
     D3 --> D4["4. next build"]

--- a/docs/architecture/frontend.mdx
+++ b/docs/architecture/frontend.mdx
@@ -62,22 +62,18 @@ The Vite configuration (`vite.config.ts`) chains several plugins in order:
 
 ### API Proxy
 
-Nitro proxies `/api/**` requests to the NestJS backend. The target is read from the `API_URL` environment variable (defaulting to `http://localhost:4000`):
+Nitro proxies `/api/**` requests to the NestJS backend via a runtime server route (`server/routes/api/[...path].ts`). The target is read from the `API_URL` environment variable (defaulting to `http://localhost:4000`):
 
 ```ts
-nitro({
-  config: {
-    devProxy: {
-      '/api/**': { target: apiTarget, changeOrigin: true },
-    },
-    routeRules: {
-      '/api/**': { proxy: `${apiTarget}/api/**` },
-    },
-  },
+// apps/web/server/routes/api/[...path].ts
+export default defineEventHandler((event) => {
+  const apiTarget = process.env.API_URL ?? `http://localhost:${process.env.API_PORT ?? 4000}`
+  const path = event.context.params?.path ?? ''
+  return proxyRequest(event, `${apiTarget}/api/${path}`)
 })
 ```
 
-This means the frontend never calls the API directly across origins -- all requests go through the same domain.
+This means the frontend never calls the API directly across origins -- all requests go through the same domain. In preview environments, the server route also injects the `x-vercel-protection-bypass` header to reach SSO-protected API previews.
 
 ## File-Based Routing
 

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -126,7 +126,7 @@ Better Auth uses **cookie-based sessions**:
 
 ### Same-origin cookies
 
-The frontend (port 3000) and API (port 4000) run on different ports in development. To keep cookies on the same origin (avoiding `SameSite=None`), the frontend uses a **Nitro dev proxy**:
+The frontend (port 3000) and API (port 4000) run on different ports in development. To keep cookies on the same origin (avoiding `SameSite=None`), the frontend uses a **Nitro server route** (`server/routes/api/[...path].ts`):
 
 ```
 /api/* → http://localhost:4000

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -94,7 +94,7 @@ bun run typecheck && bun run build
 
 **Symptom:** Login succeeds (API returns 200) but the frontend still shows the user as unauthenticated. `useSession()` returns `null`. Requests to protected routes return `401 Unauthorized`.
 
-**Cause:** Better Auth uses cookie-based sessions. In development, the frontend (port 3000) and API (port 4000) run on different ports. The dev proxy configured in `vite.config.ts` at `/api/**` forwards requests to the API so that cookies stay on the same origin (`localhost:3000`). If the proxy is not active or the frontend client sends requests directly to `localhost:4000`, cookies are set on a different origin and the browser will not include them in subsequent requests.
+**Cause:** Better Auth uses cookie-based sessions. In development, the frontend (port 3000) and API (port 4000) run on different ports. The Nitro server route at `server/routes/api/[...path].ts` proxies `/api/**` requests to the API so that cookies stay on the same origin (`localhost:3000`). If the proxy is not active or the frontend client sends requests directly to `localhost:4000`, cookies are set on a different origin and the browser will not include them in subsequent requests.
 
 Another common cause is a missing or default `BETTER_AUTH_SECRET` in `.env`. If the secret is not set, session tokens cannot be signed correctly.
 
@@ -116,7 +116,7 @@ For a full explanation of the cookie-based auth architecture, see the [Authentic
 
 **Cause:** The API's `CORS_ORIGIN` environment variable does not include the origin the browser is sending requests from. In development, `CORS_ORIGIN` defaults to `http://localhost:3000`. If you are accessing the frontend on a different host (e.g., `127.0.0.1:3000` or a custom domain), the origins will not match.
 
-Another cause is making requests directly to the API (port 4000) from frontend code instead of going through the dev proxy. The proxy eliminates CORS entirely in development because both the page and the API appear to be on the same origin.
+Another cause is making requests directly to the API (port 4000) from frontend code instead of going through the Nitro proxy. The proxy eliminates CORS entirely in development because both the page and the API appear to be on the same origin.
 
 **Fix:**
 


### PR DESCRIPTION
## Summary
- Replace stale `devProxy` config blocks with `server/routes/api/[...path].ts` code in auth-security, frontend architecture docs
- Update "Nitro dev proxy" wording to "Nitro server route" across authentication, troubleshooting, and CLAUDE.md
- Fix ci-cd.mdx Mermaid diagram: `apps/docs` → `@repo/docs` (turbo-ignore)

## Test plan
- [ ] Docs render correctly (no broken MDX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)