### PR TITLE
chore(release): add v0.8.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries are generated automatically by `/promote` and committed to staging before the promotion PR.
 
+## [v0.8.1] - 2026-03-10
+
+### Fixed
+- fix(preview): move bypass secret to runtime Nitro server route (#489)
+- fix(docs): use turbo-ignore for Vercel ignoreCommand (#490)
+
+### Documentation
+- docs: sync proxy and ignoreCommand references (#491)
+
 ## [v0.8.0] - 2026-03-10
 
 ### Added

--- a/docs/changelog/v0-8.mdx
+++ b/docs/changelog/v0-8.mdx
@@ -3,6 +3,17 @@ title: v0.8.x
 description: All v0.8 releases
 ---
 
+## v0.8.1 — March 10, 2026
+
+### Fixes
+- fix(preview): move bypass secret to runtime Nitro server route — secret is now read at request time, never baked into the build artifact (#489)
+- fix(docs): use turbo-ignore for Vercel ignoreCommand — fixes docs production deploy being skipped when no prior successful deploy exists (#490)
+
+### Documentation
+- docs: sync proxy and ignoreCommand references across architecture, auth, and troubleshooting docs (#491)
+
+---
+
 ## v0.8.0 — March 10, 2026
 
 ### Features


### PR DESCRIPTION
## Summary
- Add v0.8.1 changelog entry to CHANGELOG.md and docs/changelog/v0-8.mdx
- Patch release: bypass secret runtime fix (#489), docs turbo-ignore (#490), doc sync (#491)

🤖 Generated with [Claude Code](https://claude.com/claude-code)