### PR TITLE
fix(web): sync /talks redirect from main

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,6 +5,8 @@
   "buildCommand": "turbo run build",
   "redirects": [
     { "source": "/docs/(.*)", "destination": "https://docs.app.roxabi.com/$1", "permanent": true },
-    { "source": "/docs", "destination": "https://docs.app.roxabi.com", "permanent": true }
+    { "source": "/docs", "destination": "https://docs.app.roxabi.com", "permanent": true },
+    { "source": "/talks/(.*)", "destination": "https://talks.roxabi.com/$1", "permanent": true },
+    { "source": "/talks", "destination": "https://talks.roxabi.com", "permanent": true }
   ]
 }


### PR DESCRIPTION
## Summary
- Cherry-picks `5f4dae1` (the `/talks` redirect hotfix committed directly to main) onto staging
- Aligns staging with main so the next promotion PR will be conflict-free

## Context
PR #495 (promote v0.8.1) was conflicting because this hotfix existed on main but not staging. This sync resolves that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)