### PR TITLE
fix(dev): ensure Ctrl+C cleanly kills all dev processes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "bunx nest start --watch",
+    "dev": "bash -c 'trap \"kill 0\" INT TERM; bunx nest start --watch & wait'",
     "build": "bunx nest build",
     "start": "node dist/index",
     "start:prod": "NODE_ENV=production node dist/index",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "bash -c 'trap \"kill 0\" INT TERM; bunx nest start --watch & wait'",
+    "dev": "bash -c 'trap \"kill -INT 0\" TERM INT; bunx nest start --watch & wait'",
     "build": "bunx nest build",
     "start": "node dist/index",
     "start:prod": "NODE_ENV=production node dist/index",

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,6 +1,6 @@
 import './lib/env.server' // validates server env at startup — crashes if invalid
 import handler from '@tanstack/react-start/server-entry'
-import { paraglideMiddleware } from './paraglide/server'
+import { paraglideMiddleware } from './paraglide/server.js'
 
 // Server-side URL localization/redirects for Paraglide
 export default {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "prepare": "bash scripts/prepare.sh",
-    "dev": "set -a; [ -f .env ] && . .env; set +a; bash scripts/predev.sh && turbo dev",
+    "dev": "set -a; [ -f .env ] && . .env; set +a; bash scripts/predev.sh && exec turbo dev",
     "dev:web": "set -a; [ -f .env ] && . .env; set +a; turbo dev --filter=@repo/web",
     "dev:api": "set -a; [ -f .env ] && . .env; set +a; turbo dev --filter=@repo/api",
     "dev:docs": "turbo dev --filter=@repo/docs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
+    "dev": "bash -c 'trap \"kill 0\" INT TERM; tsc --watch & wait'",
     "generate:api-types": "bunx openapi-typescript http://localhost:4000/api/v1/docs-json -o src/lib/api-types.generated.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "bash -c 'trap \"kill 0\" INT TERM; tsc --watch & wait'",
+    "dev": "bash -c 'trap \"kill -INT 0\" TERM INT; tsc --watch & wait'",
     "generate:api-types": "bunx openapi-typescript http://localhost:4000/api/v1/docs-json -o src/lib/api-types.generated.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsup",
-    "dev": "tsup --watch & trap 'kill 0' TERM INT; email dev --dir emails --port ${EMAIL_PORT:-3001}; wait",
+    "dev": "trap 'kill -INT 0' TERM INT; tsup --watch & email dev --dir emails --port ${EMAIL_PORT:-3001}; wait",
     "preview": "email dev --dir emails --port ${EMAIL_PORT:-3001}",
     "test": "vitest run"
   },

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -56,6 +56,7 @@
     // If orphaned processes hold dev ports after Ctrl+C, run `bun run dev:clean`.
     // See https://github.com/vercel/turborepo/issues/444
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary

- Use `exec turbo dev` in root dev script to replace the intermediate bash shell with turbo directly (eliminates one signal-forwarding hop)
- Wrap `bunx nest start --watch` (api) and `tsc --watch` (cli) with `trap "kill 0" INT TERM` so SIGINT kills the full process tree — aligns with the existing pattern in `packages/email`
- Add `dependsOn: ["^build"]` to turbo `dev` task for correct startup order
- Fix paraglide import to use `.js` extension for ESM resolution

## Test plan

- [ ] Run `bun run dev` and press Ctrl+C — verify all processes (ports 3000, 4000, 3001, 42069) are released
- [ ] Confirm `bun run dev:clean` is no longer needed after a clean Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)