### PR TITLE
fix(docs): use repo root as Vercel project root

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -5,7 +5,6 @@ const withMDX = createMDX()
 
 const config: NextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
 }
 
 export default withMDX(config)

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || npx turbo-ignore @repo/docs",
-  "installCommand": "bun install --ignore-scripts",
-  "buildCommand": "bun run codegen && next build"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || bunx turbo-ignore @repo/docs",
+  "installCommand": "bun install --ignore-scripts",
+  "buildCommand": "cd apps/docs && bun run codegen && next build",
+  "outputDirectory": "apps/docs/.next"
+}


### PR DESCRIPTION
## Summary
- Promote `vercel.json` from `apps/docs/` to repo root so Vercel project root can be set to `.` — gives the full monorepo tree at build time, fixing the `../../docs` content path resolution
- Update `buildCommand` to `cd apps/docs && bun run codegen && next build` and set `outputDirectory: apps/docs/.next`
- Switch `npx turbo-ignore` → `bunx turbo-ignore` for toolchain consistency (avoids npm resolution in a Bun project)
- Remove `output: standalone` from `apps/docs/next.config.ts` — conflicts with Vercel's own build output API

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Implementation | 1 commit on `worktree-agent-a75b0496` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] In Vercel dashboard → docs project → Settings → Root Directory: set to `.` (repo root)
- [ ] Trigger a preview deploy (Actions → Deploy Preview → target: docs) and confirm build succeeds
- [ ] Verify docs content renders at the preview URL

## ⚠️ Manual Step Required
Change the Vercel docs project **Root Directory** from `apps/docs` to `.` (repo root) in the Vercel dashboard before merging. Without this, the new root `vercel.json` won't be picked up.

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`