### PR TITLE
fix(web): restore docs BookOpen icon + allow localhost in env URL validation

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@repo/ui'
 import { Link } from '@tanstack/react-router'
-import { Menu, X } from 'lucide-react'
+import { BookOpen, Menu, X } from 'lucide-react'
 import { Collapsible } from 'radix-ui'
 import { useEffect, useRef, useState } from 'react'
 import { useSession } from '@/lib/authClient'
@@ -68,6 +68,7 @@ function DesktopNavLinks() {
       {clientEnv.VITE_DOCS_URL && (
         <Button variant="ghost" size="sm" asChild>
           <a href={clientEnv.VITE_DOCS_URL} target="_blank" rel="noopener noreferrer">
+            <BookOpen className="size-4" />
             {m.nav_docs()}
           </a>
         </Button>
@@ -130,6 +131,7 @@ function MobileNavPanel({
               rel="noopener noreferrer"
               onClick={onClose}
             >
+              <BookOpen className="size-4" />
               {m.nav_docs()}
             </a>
           </Button>

--- a/apps/web/src/lib/env.shared.ts
+++ b/apps/web/src/lib/env.shared.ts
@@ -1,5 +1,15 @@
 import { z } from 'zod'
 
+const httpsUrl = (name: string) =>
+  z
+    .string()
+    .url()
+    .refine(
+      (v) => v.startsWith('https://') || v.startsWith('http://localhost'),
+      `${name} must use https (http://localhost allowed in dev)`
+    )
+    .optional()
+
 export const clientEnvSchema = z.object({
   VITE_APP_NAME: z
     .string()
@@ -7,16 +17,8 @@ export const clientEnvSchema = z.object({
     .regex(/^[\w\s\-.]+$/)
     .optional(),
   VITE_GITHUB_REPO_URL: z.string().url().optional(),
-  VITE_TALKS_URL: z
-    .string()
-    .url()
-    .refine((v) => v.startsWith('https://'), 'VITE_TALKS_URL must use https')
-    .optional(),
-  VITE_DOCS_URL: z
-    .string()
-    .url()
-    .refine((v) => v.startsWith('https://'), 'VITE_DOCS_URL must use https')
-    .optional(),
+  VITE_TALKS_URL: httpsUrl('VITE_TALKS_URL'),
+  VITE_DOCS_URL: httpsUrl('VITE_DOCS_URL'),
 })
 
 export type ClientEnv = z.infer<typeof clientEnvSchema>


### PR DESCRIPTION
## Summary
- Restore `BookOpen` icon on the docs navbar button (desktop + mobile) — was lost during the external URL refactor
- Allow `http://localhost` in `VITE_DOCS_URL` / `VITE_TALKS_URL` env validation so dev server doesn't crash

## Test plan
- [ ] Dev server starts without Zod error when `VITE_DOCS_URL=http://localhost:3002`
- [ ] Docs button shows BookOpen icon in desktop nav
- [ ] Docs button shows BookOpen icon in mobile nav
- [ ] Production URLs (`https://`) still pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)