### PR TITLE
fix(docs): revert to apps/docs as Vercel root directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || bunx turbo-ignore @repo/docs",
-  "installCommand": "bun install --ignore-scripts",
-  "buildCommand": "cd apps/docs && bun run codegen && next build",
-  "outputDirectory": "apps/docs/.next"
-}


### PR DESCRIPTION
## Summary
- Remove root `vercel.json` added in #540 — it broke Next.js detection because Vercel looks for `next` in the root `package.json`
- Vercel dashboard updated: Root Directory `.` → `apps/docs` (via API)
- `apps/docs/vercel.json` already has the correct config

The original issue (#540 was solving) was `../../docs` content path resolution. This works fine with `apps/docs` as root since Vercel clones the full monorepo. The actual fix was removing `output: standalone` (also done in #540).

## Test plan
- [ ] Verify docs.app.roxabi.com deploys successfully after merge to main
- [ ] Verify app.roxabi.com is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)