### PR TITLE
fix(docs): revert Vercel root directory to apps/docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || bunx turbo-ignore @repo/docs",
-  "installCommand": "bun install --ignore-scripts",
-  "buildCommand": "cd apps/docs && bun run codegen && next build",
-  "outputDirectory": "apps/docs/.next"
-}


### PR DESCRIPTION
## Summary
- Remove root `vercel.json` — broke Next.js detection for docs deploy
- Vercel dashboard already updated: Root Directory → `apps/docs`

Hotfix for docs.app.roxabi.com 404 after v0.9.0 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)