### PR TITLE
fix(docs): switch ignoreCommand to turbo-ignore + trigger redeploy

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || git diff $VERCEL_GIT_PREVIOUS_SHA --quiet -- apps/docs",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || bunx turbo-ignore @repo/docs",
   "installCommand": "bun install --ignore-scripts",
   "buildCommand": "bun run codegen && next build"
 }


### PR DESCRIPTION
## Summary
- Switch docs `ignoreCommand` from `git diff` to `turbo-ignore` for reliable monorepo change detection
- This change to `apps/docs/vercel.json` will trigger the first successful docs deploy with the corrected Root Directory setting

Follows #546 (root directory fix).

## Test plan
- [ ] Verify docs.app.roxabi.com returns 200 after promotion to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)