### PR TITLE
fix(ci): enable auto-merge with PAT so merge pushes trigger staging CI

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -53,7 +53,11 @@ jobs:
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
-          GH_TOKEN: ${{ github.token }}
+          # PAT, not github.token: the eventual merge push is attributed to the enabling
+          # token, and GITHUB_TOKEN-attributed pushes never trigger push workflows
+          # (anti-recursion) — staging CI (e2e-matrix, boot-smoke) silently skipped
+          # on every auto-merged PR (#587/#588). All other Roxabi repos use PAT here.
+          GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, staging]
   push:
     branches: [main, staging]
+  # Manual backfill (e.g. validate a merged state whose push didn't trigger CI)
+  workflow_dispatch:
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Summary
- **Root cause**: the `Enable auto-merge` job armed auto-merge with `github.token`. GitHub attributes the eventual merge push to the enabling token, and GITHUB_TOKEN-attributed pushes never trigger push workflows (anti-recursion guard). Result: **every auto-merged PR landed on staging with zero push CI** — no e2e-matrix, no post-merge validation (#587 and #588 both confirmed: no CI run on their merge pushes; the last staging CI run dates from a direct push).
- Switch to `secrets.PAT` — already the convention in every other Roxabi repo (factory, plugins, live, forge, imageCLI, production, voiceCLI, llmCLI); boilerplate was the lone exception. `update-behind-prs` here already uses PAT.
- Add `workflow_dispatch` to ci.yml for manual backfill of the current merged-but-unvalidated staging state.

Found while verifying Lot 2 (#588): the dead-gate class strikes again — gate exists, runs green on PRs, silently never runs post-merge.

## Test Plan
- [ ] This PR merges via auto-merge (armed with old token — last silent merge)
- [ ] `gh workflow run ci.yml --ref staging` backfill goes green (incl. e2e-matrix + boot-smoke on push path)
- [ ] Next auto-merged PR triggers a push CI run on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)