### PR TITLE
chore: set EMAIL_FROM to no-reply@roxabi.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string  # Generate: openssl ran
 # ─── Email — Resend (Optional) ───────────────────────────────
 # On Vercel: auto-injected by Resend Marketplace integration
 # RESEND_API_KEY=
-EMAIL_FROM=noreply@yourdomain.com
+EMAIL_FROM=no-reply@roxabi.dev
 
 # ─── Docker (Optional — override to run multiple projects on the same machine) ─
 # All container/volume names derive from APP_SLUG (see docker-compose.yml)


### PR DESCRIPTION
## Why

`roxabi.dev` is now verified in Resend. Replace the `.env.example` placeholder so the documented default sends from the brand domain.

Live Vercel `EMAIL_FROM` on `roxabi-api` (prod+preview) was already updated to `Roxabi <no-reply@roxabi.dev>` out-of-band; this aligns the repo default.

## Change

- `.env.example`: `EMAIL_FROM=noreply@yourdomain.com` → `no-reply@roxabi.dev`

## Test plan

- [x] pre-push gate green (lint, lint-custom, typecheck, tests, i18n, license)

🤖 Generated with [Claude Code](https://claude.com/claude-code)