### PR TITLE
docs(agent-memory): fix stale landing/seed-user claims

### DIFF
--- a/.claude/agent-memory/frontend-dev/MEMORY.md
+++ b/.claude/agent-memory/frontend-dev/MEMORY.md
@@ -1,36 +1,10 @@
 # Frontend Dev Memory
 
-## Terminal Dark / Hacker Aesthetic (v10 pattern)
+## Landing Page Conventions
 
-- Inject CSS via `const STYLES = \`...\`` rendered as `<style>{STYLES}</style>` inside root component
-- Namespace all CSS classes with version prefix (e.g., `v10-`) to avoid global collisions
-- Fonts: JetBrains Mono (headlines/code) + IBM Plex Sans (body) — loaded via `@import url(...)` inside STYLES
-- Colors: bg `#0F172A`→`#020617`, green `#22C55E`, cyan `#06B6D4`, muted `#64748B`
-- Terminal panel: `background: #020617`, `border: 1px solid #1e293b`, CRT scanline via `::before` repeating-linear-gradient
-- Blinking cursor: `animation: blink 1.1s step-end infinite` — step-end is required for digital feel
-- Scanline sweep: positioned `::after` pseudo-element animating `translateY` on scanline-overlay class
-- Scrolling ticker: duplicate array `[...arr, ...arr]` + `translateX(-50%)` animation
-- Always add `@media (prefers-reduced-motion: reduce)` to disable all animations
+- `apps/web/src/routes/index.tsx` is NOT self-contained — it composes 7 section components from `@/components/landing/` (Hero, Features, AiTeam, Dx, TechStack, Stats, Cta); every section except Hero is wrapped in `<AnimatedSection>` from `@repo/ui`
+- Section data (features, agents, tech groups, stats) is built as a local array INSIDE the component function, not hoisted to a module-top `const ... = [...] as const` — the arrays call `m.xxx()` Paraglide message functions, which must run at render time (only `HeroSection`'s static, non-translated `TERMINAL_LINES` is a module-top `as const` array)
+- Sub-component prop types are inline destructured object types extending `React.ComponentProps<'div'>` etc. (e.g. `FeatureCard`, `SectionHeading`), not standalone `type XxxProps = { ... }` declarations
+- `cn()` from `@repo/ui` is used only for conditional className composition (e.g. `FeaturesSection`'s docs-link hover state, `SectionHeading`'s `className` override) — static strings don't need it
 
-## Landing Page Conventions (v11 pattern)
-
-- Self-contained route files go in `apps/web/src/routes/` — no imports from `@/components/landing/`
-- All data arrays defined as `const ... = [...] as const` at module top — keeps component functions clean
-- Props types: `type XxxProps = { ... }` with `Props` suffix, placed immediately before the function
-- `noUncheckedIndexedAccess` + `TS6133`: always remove unused imports before finishing (e.g., unused lucide icons cause TS6133 error)
-- Tailwind v4 arbitrary values work fine: `bg-[#ECFEFF]`, `text-[#164E63]/70`, `tracking-[0.2em]`
-- No `cn()` needed when classNames are static strings — only import from `@repo/ui` when conditionally composing classes
-- `as const` on `readonly string[]` feature arrays: the `PricingCardProps.features` type should be `readonly string[]` to accept `as const` tuples passed from the data array
-
-## TypeScript Gotchas
-
-- `noUncheckedIndexedAccess`: array[i] returns T | undefined — use `?? fallback`
-- `TS6133`: unused imports/destructured params are errors — remove before submitting
-- `as const` arrays passed to props typed `string[]` cause type errors — type props as `readonly string[]`
-
-## CSS Injection Pattern (v13 glassmorphism)
-
-- Inject CSS as `<style>{GLOBAL_STYLES}</style>` — avoids the security hook that fires on dangerouslySetInnerHTML, works equally well for compile-time string constants
-- Glassmorphism: `backdrop-filter: blur(20px)` requires both `-webkit-backdrop-filter` and `backdrop-filter` for cross-browser support
-- Gradient orbs: `position: absolute; border-radius: 50%; filter: blur(80px); pointer-events: none; z-index: 0` — parent must be `overflow-hidden` and `relative`
-- Glass card: `background: rgba(255,255,255,0.60)` + `border: 1px solid rgba(255,255,255,0.4)` + `box-shadow: inset 0 1px 0 rgba(255,255,255,0.8)` — the inset top highlight is the key premium effect
+<!-- 2026-06-15 cleanup: v10 hacker-aesthetic + v13 glassmorphism deleted (one-off dead experiments, no live route); TS Gotchas promoted → roxabi-boilerplate/CLAUDE.md Gotchas -->

--- a/.claude/agent-memory/tester/MEMORY.md
+++ b/.claude/agent-memory/tester/MEMORY.md
@@ -19,7 +19,7 @@ Key conventions observed in `/apps/web/e2e/`:
 - Submit: `getByRole('button', { name: /create account|sign up|register|creating/i })`
 - Success state: renders `RegistrationSuccess` component with `backToLoginLink` (link to `/login`)
 - Error: `[data-slot="form-message"]` for API errors; `#email-error` for inline email validation
-- Existing seed user for duplicate email test: `dev@roxabi.local`
+- Existing seed user for duplicate email test: `TEST_USER.email` from `testHelpers.ts` (derived `dev@${SEED_SLUG}.local`) — do NOT hardcode a literal, it changes per repo/env (see Seeded Test Users)
 
 ## Profile Page (`/settings/profile`)
 
@@ -43,9 +43,11 @@ Key conventions observed in `/apps/web/e2e/`:
 
 ## Seeded Test Users
 
-- `TEST_USER`: `dev@roxabi.local` / `password123` — used for shared auth setup
-- `TEST_USER_2`: `admin@roxabi.local` / `password123` — used for unauthenticated tests
-- `SUPERADMIN_USER`: `superadmin@roxabi.local` / `password123` — superadmin session
+- `testHelpers.ts`: `SEED_SLUG = process.env.APP_SLUG ?? process.env.POSTGRES_DB ?? 'app'` — NEVER hardcode literal emails, they're derived from this slug
+- `TEST_USER`: `dev@${SEED_SLUG}.local` / `password123` — used for shared auth setup
+- `TEST_USER_2`: `admin@${SEED_SLUG}.local` / `password123` — used for unauthenticated tests
+- `SUPERADMIN_USER`: `superadmin@${SEED_SLUG}.local` / `password123` — superadmin session
+- Local `.env` sets `APP_SLUG` per repo (e.g. `roxabi` here) so locally this resolves to `dev@roxabi.local` etc.; CI sets `POSTGRES_DB=ci` (no `APP_SLUG`) so CI resolves to `dev@ci.local` etc. — always read `TEST_USER.email`, never assume the literal
 
 ## E2E Import Conventions
 
@@ -57,15 +59,15 @@ Key conventions observed in `/apps/web/e2e/`:
 ## Auth Storage Paths
 
 - Regular user: `./apps/web/e2e/.auth/user.json` (from `auth.setup.ts`)
-- Superadmin: `./apps/web/e2e/.auth/superadmin.json` (from `system-admin.setup.ts`)
+- Superadmin: `./apps/web/e2e/.auth/superadmin.json` (from `systemAdmin.setup.ts`)
 - Paths are relative to repo root (config lives at repo root)
 
 ## Playwright Config Pattern (`packages/playwright-config/base.ts`)
 
 - Setup projects use `testMatch` regexp; browser projects use `testIgnore` regexp
 - Regular browser projects must ignore BOTH setup files AND spec files for dedicated projects
-- `testIgnore` for regular browsers: `/(?:auth|system-admin)\.setup\.ts|system-admin\.spec\.ts/`
-- Dedicated project for system-admin: `testMatch: /system-admin\.spec\.ts/`
+- `testIgnore` for regular browsers: `/(?:auth|systemAdmin)\.setup\.ts|systemAdmin\.spec\.ts/`
+- Dedicated project for system-admin: `testMatch: /systemAdmin\.spec\.ts/`
 - All conditional project additions are guarded: `...(hasDatabase ? [...] : [])`
 
 ## Admin UI Structure


### PR DESCRIPTION
## Summary
- `frontend-dev/MEMORY.md`: rewrote "Landing Page Conventions" — the "self-contained route, no imports from `@/components/landing/`" claim is contradicted by `apps/web/src/routes/index.tsx`, which composes 7 section components from `@/components/landing/`; also removed dead references (`PricingCardProps` no longer exists anywhere in the repo, module-top `as const` arrays and `Props`-suffix types are not actually used in the current landing sections)
- `tester/MEMORY.md`: replaced hardcoded `dev@roxabi.local`/`admin@roxabi.local`/`superadmin@roxabi.local` literals with the actual `SEED_SLUG` derivation rule from `apps/web/e2e/testHelpers.ts` (`SEED_SLUG = APP_SLUG ?? POSTGRES_DB ?? 'app'`) — the literals only worked locally in this repo by coincidence (`.env` sets `APP_SLUG=roxabi`) and are wrong in CI (`POSTGRES_DB=ci` → `dev@ci.local`)
- `tester/MEMORY.md`: fixed `system-admin.setup.ts` → actual `systemAdmin.setup.ts`, and fixed the `testMatch`/`testIgnore` regex casing to match `packages/playwright-config/base.ts` (`systemAdmin`, camelCase, no hyphen)

Every fact was re-verified against current code before writing (see commit body). Part of approved memory-audit doc promotions.

## Test plan
- [x] `bun run lint` (exit 0, pre-existing unrelated warnings only)
- [x] `bun run typecheck` (exit 0)
- [x] `bun run test` (2336 tests passed)
- [x] `bun run i18n:check` (exit 0)
- [x] `bun run license:check` (exit 0)
- [x] `bun run lint:custom` (exit 0)
- [x] `bun run mdx:check` (exit 0)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>